### PR TITLE
Add language selector, per-catalog card layout, Better Posters integr…

### DIFF
--- a/Eclipse.xcodeproj/project.pbxproj
+++ b/Eclipse.xcodeproj/project.pbxproj
@@ -280,6 +280,8 @@
 		AA1111112F10000000AA1111 /* TrackerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1111102F10000000AA1110 /* TrackerManager.swift */; };
 		AA2222222F10000000AA2222 /* TrackerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2222202F10000000AA2220 /* TrackerModels.swift */; };
 		AA3333332F10000000AA3333 /* TrackersSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3333302F10000000AA3330 /* TrackersSettingsView.swift */; };
+		AA9999912F10000000AA9991 /* LanguageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9999902F10000000AA9990 /* LanguageSettingsView.swift */; };
+		AA9999922F10000000AA9992 /* LanguageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9999902F10000000AA9990 /* LanguageSettingsView.swift */; };
 		AA4444442F10000000AA4444 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4444402F10000000AA4440 /* ScheduleView.swift */; };
 		AA5555552F10000000AA5555 /* CatalogManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5555502F10000000AA5550 /* CatalogManager.swift */; };
 		PROBF0100000000000000001 /* ProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = PROFR0100000000000000001 /* ProfileManager.swift */; };
@@ -595,6 +597,7 @@
 		AA1111102F10000000AA1110 /* TrackerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackerManager.swift; sourceTree = "<group>"; };
 		AA2222202F10000000AA2220 /* TrackerModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackerModels.swift; sourceTree = "<group>"; };
 		AA3333302F10000000AA3330 /* TrackersSettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackersSettingsView.swift; sourceTree = "<group>"; };
+		AA9999902F10000000AA9990 /* LanguageSettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LanguageSettingsView.swift; sourceTree = "<group>"; };
 		AA4444402F10000000AA4440 /* ScheduleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduleView.swift; sourceTree = "<group>"; };
 		AA5555502F10000000AA5550 /* CatalogManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CatalogManager.swift; sourceTree = "<group>"; };
 		PROFR0100000000000000001 /* ProfileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileManager.swift; sourceTree = "<group>"; };
@@ -1417,6 +1420,7 @@
 				14BBB0043FFF111100AAAAAA /* BackupManagementView.swift */,
 				AA3333302F10000000AA3330 /* TrackersSettingsView.swift */,
 				AA6666602F10000000AA6660 /* CatalogsSettingsView.swift */,
+				AA9999902F10000000AA9990 /* LanguageSettingsView.swift */,
 			);
 			path = SettingsView;
 			sourceTree = "<group>";
@@ -1630,6 +1634,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				es,
 				Base,
 			);
 			mainGroup = 13F072522E4B2D3300EF90EB;
@@ -1857,6 +1862,7 @@
 				AA1111112F10000000AA1111 /* TrackerManager.swift in Sources */,
 				AA2222222F10000000AA2222 /* TrackerModels.swift in Sources */,
 				AA3333332F10000000AA3333 /* TrackersSettingsView.swift in Sources */,
+				AA9999912F10000000AA9991 /* LanguageSettingsView.swift in Sources */,
 				AA4444442F10000000AA4444 /* ScheduleView.swift in Sources */,
 				AA5555552F10000000AA5555 /* CatalogManager.swift in Sources */,
 				PROBF0200000000000000002 /* ProfileManager.swift in Sources */,
@@ -2058,6 +2064,7 @@
 				AA1111112F10000000AA1111 /* TrackerManager.swift in Sources */,
 				AA2222222F10000000AA2222 /* TrackerModels.swift in Sources */,
 				AA3333332F10000000AA3333 /* TrackersSettingsView.swift in Sources */,
+				AA9999922F10000000AA9992 /* LanguageSettingsView.swift in Sources */,
 				AA4444442F10000000AA4444 /* ScheduleView.swift in Sources */,
 				AA5555552F10000000AA5555 /* CatalogManager.swift in Sources */,
 				PROBF0100000000000000001 /* ProfileManager.swift in Sources */,

--- a/Eclipse.xcodeproj/project.pbxproj
+++ b/Eclipse.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		13830AF22E55F51300B3CDE4 /* AlternativeUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13830AF12E55F51300B3CDE4 /* AlternativeUIView.swift */; };
 		14CC00040000000000CC0004 /* HomeLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CC00030000000000CC0003 /* HomeLayoutView.swift */; };
 		14CC00020000000000CC0002 /* HomeCatalogLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CC00010000000000CC0001 /* HomeCatalogLayout.swift */; };
+		FD4A01A3F39CC98E8F09819F /* BetterPostersSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A934277CAAC3BCE3BEBE7EDE /* BetterPostersSettings.swift */; };
 		UPNX00020000000000000002 /* UpNextResolutionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = UPNX00010000000000000001 /* UpNextResolutionCache.swift */; };
 		UPNX00030000000000000003 /* UpNextResolutionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = UPNX00010000000000000001 /* UpNextResolutionCache.swift */; };
 		13830AF42E55F5FF00B3CDE4 /* AccentColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13830AF32E55F5FF00B3CDE4 /* AccentColorManager.swift */; };
@@ -280,8 +281,8 @@
 		AA1111112F10000000AA1111 /* TrackerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1111102F10000000AA1110 /* TrackerManager.swift */; };
 		AA2222222F10000000AA2222 /* TrackerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2222202F10000000AA2220 /* TrackerModels.swift */; };
 		AA3333332F10000000AA3333 /* TrackersSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3333302F10000000AA3330 /* TrackersSettingsView.swift */; };
-		AA9999912F10000000AA9991 /* LanguageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9999902F10000000AA9990 /* LanguageSettingsView.swift */; };
-		AA9999922F10000000AA9992 /* LanguageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9999902F10000000AA9990 /* LanguageSettingsView.swift */; };
+		AA2E835F9AE57A62496ADB19 /* LanguageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24C91CE36D3719D857ABED4 /* LanguageSettingsView.swift */; };
+		D6AF41CBD6272EFEC06978B9 /* LanguageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24C91CE36D3719D857ABED4 /* LanguageSettingsView.swift */; };
 		AA4444442F10000000AA4444 /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4444402F10000000AA4440 /* ScheduleView.swift */; };
 		AA5555552F10000000AA5555 /* CatalogManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5555502F10000000AA5550 /* CatalogManager.swift */; };
 		PROBF0100000000000000001 /* ProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = PROFR0100000000000000001 /* ProfileManager.swift */; };
@@ -593,11 +594,12 @@
 		14BBB0043FFF111100AAAAAA /* BackupManagementView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackupManagementView.swift; sourceTree = "<group>"; };
 		14BBB0063FFF111100AAAAAA /* BackupManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackupManager.swift; sourceTree = "<group>"; };
 		14CC00010000000000CC0001 /* HomeCatalogLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeCatalogLayout.swift; sourceTree = "<group>"; };
+		A934277CAAC3BCE3BEBE7EDE /* BetterPostersSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BetterPostersSettings.swift; sourceTree = "<group>"; };
 		UPNX00010000000000000001 /* UpNextResolutionCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpNextResolutionCache.swift; sourceTree = "<group>"; };
 		AA1111102F10000000AA1110 /* TrackerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackerManager.swift; sourceTree = "<group>"; };
 		AA2222202F10000000AA2220 /* TrackerModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackerModels.swift; sourceTree = "<group>"; };
 		AA3333302F10000000AA3330 /* TrackersSettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackersSettingsView.swift; sourceTree = "<group>"; };
-		AA9999902F10000000AA9990 /* LanguageSettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LanguageSettingsView.swift; sourceTree = "<group>"; };
+		E24C91CE36D3719D857ABED4 /* LanguageSettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LanguageSettingsView.swift; sourceTree = "<group>"; };
 		AA4444402F10000000AA4440 /* ScheduleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduleView.swift; sourceTree = "<group>"; };
 		AA5555502F10000000AA5550 /* CatalogManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CatalogManager.swift; sourceTree = "<group>"; };
 		PROFR0100000000000000001 /* ProfileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileManager.swift; sourceTree = "<group>"; };
@@ -1420,7 +1422,7 @@
 				14BBB0043FFF111100AAAAAA /* BackupManagementView.swift */,
 				AA3333302F10000000AA3330 /* TrackersSettingsView.swift */,
 				AA6666602F10000000AA6660 /* CatalogsSettingsView.swift */,
-				AA9999902F10000000AA9990 /* LanguageSettingsView.swift */,
+				E24C91CE36D3719D857ABED4 /* LanguageSettingsView.swift */,
 			);
 			path = SettingsView;
 			sourceTree = "<group>";
@@ -1453,6 +1455,7 @@
 				13F5B5932E730B0200565E75 /* Library */,
 				14BBB0063FFF111100AAAAAA /* BackupManager.swift */,
 				14CC00010000000000CC0001 /* HomeCatalogLayout.swift */,
+				A934277CAAC3BCE3BEBE7EDE /* BetterPostersSettings.swift */,
 				UPNX00010000000000000001 /* UpNextResolutionCache.swift */,
 				13C6F3452EA4C6BC00DECD2B /* CacheManager.swift */,
 				DD1111102FB0000000DD1110 /* DownloadManager.swift */,
@@ -1862,7 +1865,7 @@
 				AA1111112F10000000AA1111 /* TrackerManager.swift in Sources */,
 				AA2222222F10000000AA2222 /* TrackerModels.swift in Sources */,
 				AA3333332F10000000AA3333 /* TrackersSettingsView.swift in Sources */,
-				AA9999912F10000000AA9991 /* LanguageSettingsView.swift in Sources */,
+				AA2E835F9AE57A62496ADB19 /* LanguageSettingsView.swift in Sources */,
 				AA4444442F10000000AA4444 /* ScheduleView.swift in Sources */,
 				AA5555552F10000000AA5555 /* CatalogManager.swift in Sources */,
 				PROBF0200000000000000002 /* ProfileManager.swift in Sources */,
@@ -1904,6 +1907,7 @@
 				5E4444412F60000000AE4441 /* StremioAddonManager.swift in Sources */,
 				13F187AC2E6F38CE00747F7E /* LibraryManager.swift in Sources */,
 				14CC00020000000000CC0002 /* HomeCatalogLayout.swift in Sources */,
+				FD4A01A3F39CC98E8F09819F /* BetterPostersSettings.swift in Sources */,
 				UPNX00020000000000000002 /* UpNextResolutionCache.swift in Sources */,
 				A1B2C3012FA0000100A1B2C1 /* EclipseTheme.swift in Sources */,
 				A1B2C3032FA0000100A1B2C3 /* HeroTransition.swift in Sources */,
@@ -2064,7 +2068,7 @@
 				AA1111112F10000000AA1111 /* TrackerManager.swift in Sources */,
 				AA2222222F10000000AA2222 /* TrackerModels.swift in Sources */,
 				AA3333332F10000000AA3333 /* TrackersSettingsView.swift in Sources */,
-				AA9999922F10000000AA9992 /* LanguageSettingsView.swift in Sources */,
+				D6AF41CBD6272EFEC06978B9 /* LanguageSettingsView.swift in Sources */,
 				AA4444442F10000000AA4444 /* ScheduleView.swift in Sources */,
 				AA5555552F10000000AA5555 /* CatalogManager.swift in Sources */,
 				PROBF0100000000000000001 /* ProfileManager.swift in Sources */,
@@ -2115,6 +2119,7 @@
 				14BBB0033FFF111100AAAAAA /* BackupManagementView.swift in Sources */,
 				14BBB0053FFF111100AAAAAA /* BackupManager.swift in Sources */,
 				14CC00020000000000CC0002 /* HomeCatalogLayout.swift in Sources */,
+				FD4A01A3F39CC98E8F09819F /* BetterPostersSettings.swift in Sources */,
 				UPNX00030000000000000003 /* UpNextResolutionCache.swift in Sources */,
 				FF1111112F30000000FF1111 /* AniListMangaService.swift in Sources */,
 				FF2222222F30000000FF2222 /* MangaCatalogManager.swift in Sources */,

--- a/Eclipse/Localizable.xcstrings
+++ b/Eclipse/Localizable.xcstrings
@@ -9,6 +9,12 @@
             "state": "translated",
             "value": "Accent Color"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de acento"
+          }
         }
       }
     },
@@ -19,6 +25,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Activate at least one stream-capable service, addon, or plugin to use Auto Mode."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa al menos un servicio, addon o plugin compatible con transmisión para usar el Modo Automático."
           }
         }
       }
@@ -31,6 +43,12 @@
             "state": "translated",
             "value": "Add"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar"
+          }
         }
       }
     },
@@ -41,6 +59,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Add Service"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar servicio"
           }
         }
       }
@@ -53,6 +77,12 @@
             "state": "translated",
             "value": "Add Stremio Addon"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar addon de Stremio"
+          }
         }
       }
     },
@@ -63,6 +93,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Add to Collection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar a la colección"
           }
         }
       }
@@ -75,6 +111,12 @@
             "state": "translated",
             "value": "Added lists appear in Catalogs for ordering and per-row toggles."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las listas agregadas aparecen en Catálogos para ordenarlas y activarlas por fila."
+          }
         }
       }
     },
@@ -85,6 +127,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del addon"
           }
         }
       }
@@ -97,16 +145,11 @@
             "state": "translated",
             "value": "Affects buttons, links and other interactive elements."
           }
-        }
-      }
-    },
-    "Animated Background": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Animated Background"
+            "value": "Afecta botones, enlaces y otros elementos interactivos."
           }
         }
       }
@@ -119,6 +162,29 @@
             "state": "translated",
             "value": "Animate the top-right Media and Reader mode switch."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anima el interruptor de modo Media/Lector de la esquina superior derecha."
+          }
+        }
+      }
+    },
+    "Animated Background": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animated Background"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondo animado"
+          }
         }
       }
     },
@@ -129,6 +195,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "App Experience"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experiencia de la app"
           }
         }
       }
@@ -141,6 +213,12 @@
             "state": "translated",
             "value": "App Updates"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones de la app"
+          }
         }
       }
     },
@@ -151,6 +229,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Appearance"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apariencia"
           }
         }
       }
@@ -163,6 +247,12 @@
             "state": "translated",
             "value": "Ascending"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ascendente"
+          }
         }
       }
     },
@@ -173,6 +263,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auto Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo automático"
           }
         }
       }
@@ -185,6 +281,12 @@
             "state": "translated",
             "value": "Auto Quality"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calidad automática"
+          }
         }
       }
     },
@@ -196,16 +298,11 @@
             "state": "translated",
             "value": "Auto Sync Ratings"
           }
-        }
-      }
-    },
-    "Auto-check GitHub Releases": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auto-check GitHub Releases"
+            "value": "Sincronizar calificaciones automáticamente"
           }
         }
       }
@@ -218,6 +315,12 @@
             "state": "translated",
             "value": "Auto-Select Episodes"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selección automática de episodios"
+          }
         }
       }
     },
@@ -228,6 +331,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auto-Select Episodes also applies when choosing a source manually. Auto Mode checks enabled sources from top to bottom. Drag to set priority, and turn Auto Quality off when you want to choose stream quality yourself."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La selección automática de episodios también aplica al elegir una fuente manualmente. El Modo Automático revisa las fuentes activadas de arriba hacia abajo. Arrastra para establecer la prioridad y desactiva la Calidad Automática cuando quieras elegir tú mismo la calidad de la transmisión."
           }
         }
       }
@@ -240,6 +349,29 @@
             "state": "translated",
             "value": "Auto-Update Services"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar servicios automáticamente"
+          }
+        }
+      }
+    },
+    "Auto-check GitHub Releases": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-check GitHub Releases"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar lanzamientos de GitHub automáticamente"
+          }
         }
       }
     },
@@ -250,6 +382,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Automatically check for service updates when the app is opened."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busca actualizaciones de servicios automáticamente al abrir la app."
           }
         }
       }
@@ -262,6 +400,12 @@
             "state": "translated",
             "value": "Backup & Import"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia de seguridad e importación"
+          }
         }
       }
     },
@@ -272,6 +416,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Backup & Restore"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia de seguridad y restauración"
           }
         }
       }
@@ -284,6 +434,12 @@
             "state": "translated",
             "value": "Banner color bleeds, then the background takes over"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El color del banner se difumina y luego domina el fondo"
+          }
         }
       }
     },
@@ -294,6 +450,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cancel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         }
       }
@@ -306,6 +468,12 @@
             "state": "translated",
             "value": "Cancel All Active"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar todo lo activo"
+          }
         }
       }
     },
@@ -316,6 +484,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cast"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transmitir"
           }
         }
       }
@@ -328,6 +502,12 @@
             "state": "translated",
             "value": "Catalog name (optional)"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del catálogo (opcional)"
+          }
         }
       }
     },
@@ -338,6 +518,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogos"
           }
         }
       }
@@ -350,6 +536,12 @@
             "state": "translated",
             "value": "Category"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categoría"
+          }
         }
       }
     },
@@ -360,6 +552,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Choose a server to stream from"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un servidor desde el cual transmitir"
           }
         }
       }
@@ -372,6 +570,12 @@
             "state": "translated",
             "value": "Choose a subtitle track"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una pista de subtítulos"
+          }
         }
       }
     },
@@ -382,6 +586,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Choose an episode:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un episodio:"
           }
         }
       }
@@ -394,6 +604,12 @@
             "state": "translated",
             "value": "Classic"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clásico"
+          }
         }
       }
     },
@@ -404,6 +620,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Classic Gradient"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Degradado clásico"
           }
         }
       }
@@ -416,6 +638,12 @@
             "state": "translated",
             "value": "Clear"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
         }
       }
     },
@@ -426,6 +654,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Clear All Logs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar todos los registros"
           }
         }
       }
@@ -438,6 +672,12 @@
             "state": "translated",
             "value": "Clear Cache?"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Borrar caché?"
+          }
         }
       }
     },
@@ -448,6 +688,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Clear Reader Logs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar registros del lector"
           }
         }
       }
@@ -460,6 +706,12 @@
             "state": "translated",
             "value": "Collection Name"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre de la colección"
+          }
         }
       }
     },
@@ -467,6 +719,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color 1"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Color 1"
@@ -482,6 +740,12 @@
             "state": "translated",
             "value": "Color 2"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color 2"
+          }
         }
       }
     },
@@ -489,6 +753,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color 3"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Color 3"
@@ -504,6 +774,12 @@
             "state": "translated",
             "value": "Community"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comunidad"
+          }
         }
       }
     },
@@ -514,6 +790,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Company"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empresa"
           }
         }
       }
@@ -526,6 +808,12 @@
             "state": "translated",
             "value": "Configuration"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración"
+          }
         }
       }
     },
@@ -536,6 +824,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Configure"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar"
           }
         }
       }
@@ -548,6 +842,12 @@
             "state": "translated",
             "value": "Configure this addon on the web, then use \"Update URL\" to paste the new URL."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configura este addon en la web y luego usa \"Actualizar URL\" para pegar la nueva URL."
+          }
         }
       }
     },
@@ -558,6 +858,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Configured addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del addon configurado"
           }
         }
       }
@@ -570,6 +876,12 @@
             "state": "translated",
             "value": "Connect"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar"
+          }
         }
       }
     },
@@ -580,6 +892,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connection Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de conexión"
           }
         }
       }
@@ -592,6 +910,12 @@
             "state": "translated",
             "value": "Content Catalogs"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogos de contenido"
+          }
         }
       }
     },
@@ -602,6 +926,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Copy Log Message"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar mensaje del registro"
           }
         }
       }
@@ -614,6 +944,12 @@
             "state": "translated",
             "value": "Create"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear"
+          }
         }
       }
     },
@@ -624,6 +960,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Create New Collection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear nueva colección"
           }
         }
       }
@@ -636,6 +978,12 @@
             "state": "translated",
             "value": "Custom Background Color"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de fondo personalizado"
+          }
         }
       }
     },
@@ -646,6 +994,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Custom palette colors blend into a multi-gradient. Pick three."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los colores de la paleta personalizada se combinan en un multidegradado. Elige tres."
           }
         }
       }
@@ -658,6 +1012,12 @@
             "state": "translated",
             "value": "Custom size"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño personalizado"
+          }
         }
       }
     },
@@ -668,6 +1028,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Data"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datos"
           }
         }
       }
@@ -680,6 +1046,12 @@
             "state": "translated",
             "value": "Default"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado"
+          }
         }
       }
     },
@@ -690,6 +1062,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Delete"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
           }
         }
       }
@@ -702,6 +1080,12 @@
             "state": "translated",
             "value": "Delete All"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar todo"
+          }
         }
       }
     },
@@ -712,6 +1096,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Delete All Downloads"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar todas las descargas"
           }
         }
       }
@@ -724,6 +1114,12 @@
             "state": "translated",
             "value": "Delete Completed"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar completados"
+          }
         }
       }
     },
@@ -734,6 +1130,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Delete Download"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar descarga"
           }
         }
       }
@@ -746,6 +1148,12 @@
             "state": "translated",
             "value": "Delete Episode"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar episodio"
+          }
         }
       }
     },
@@ -756,6 +1164,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Descending"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descendente"
           }
         }
       }
@@ -768,6 +1182,12 @@
             "state": "translated",
             "value": "Description (optional)"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descripción (opcional)"
+          }
         }
       }
     },
@@ -778,6 +1198,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Detail Pages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Páginas de detalle"
           }
         }
       }
@@ -790,6 +1216,12 @@
             "state": "translated",
             "value": "Details"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles"
+          }
         }
       }
     },
@@ -800,6 +1232,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Direction"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección"
           }
         }
       }
@@ -812,6 +1250,12 @@
             "state": "translated",
             "value": "Disabled by repo"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deshabilitado por el repositorio"
+          }
         }
       }
     },
@@ -822,6 +1266,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Disconnect"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar"
           }
         }
       }
@@ -834,6 +1284,12 @@
             "state": "translated",
             "value": "Done"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo"
+          }
         }
       }
     },
@@ -844,6 +1300,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Download"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar"
           }
         }
       }
@@ -856,6 +1318,12 @@
             "state": "translated",
             "value": "Downloads"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargas"
+          }
         }
       }
     },
@@ -866,6 +1334,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Drag rows to change their order. Hidden rows will not appear on media detail pages. Episodes only appear for series. Stills and Trailers appear in the Modern interface."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrastra las filas para cambiar su orden. Las filas ocultas no aparecerán en las páginas de detalle. Los episodios solo aparecen para series. Las capturas y los tráilers aparecen en la interfaz Moderna."
           }
         }
       }
@@ -878,6 +1352,12 @@
             "state": "translated",
             "value": "Eclipse is a GPL-licensed media app with substantial original changes by Soupy-dev."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse es una app multimedia con licencia GPL, con cambios originales considerables realizados por Soupy-dev."
+          }
         }
       }
     },
@@ -888,6 +1368,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eclipse is released under the GNU General Public License version 3."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse se distribuye bajo la Licencia Pública General de GNU versión 3."
           }
         }
       }
@@ -900,6 +1386,12 @@
             "state": "translated",
             "value": "Eclipse's privacy policy explains what data the app stores locally and how optional third-party services are handled."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La política de privacidad de Eclipse explica qué datos almacena la app localmente y cómo se gestionan los servicios opcionales de terceros."
+          }
         }
       }
     },
@@ -910,6 +1402,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Empty"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vacío"
           }
         }
       }
@@ -922,6 +1420,12 @@
             "state": "translated",
             "value": "Enable Sync"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar sincronización"
+          }
         }
       }
     },
@@ -932,6 +1436,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enable/disable content catalogs and drag to reorder them. The order here determines the order on your home screen. Stremio catalog addons may reduce performance or have visual inconsistencies. Trakt catalogs appear after Trakt is connected."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva los catálogos de contenido y arrástralos para reordenarlos. El orden aquí determina el orden en tu pantalla de inicio. Los addons de catálogo de Stremio pueden reducir el rendimiento o tener inconsistencias visuales. Los catálogos de Trakt aparecen después de conectar Trakt."
           }
         }
       }
@@ -944,6 +1454,12 @@
             "state": "translated",
             "value": "Enter decimal number"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa un número decimal"
+          }
         }
       }
     },
@@ -954,6 +1470,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enter number"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa un número"
           }
         }
       }
@@ -966,16 +1488,11 @@
             "state": "translated",
             "value": "Enter text"
           }
-        }
-      }
-    },
-    "Enter the direct JSON file URL": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Enter the direct JSON file URL"
+            "value": "Ingresa texto"
           }
         }
       }
@@ -988,6 +1505,29 @@
             "state": "translated",
             "value": "Enter the Stremio addon manifest URL"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa la URL del manifiesto del addon de Stremio"
+          }
+        }
+      }
+    },
+    "Enter the direct JSON file URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter the direct JSON file URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa la URL directa del archivo JSON"
+          }
         }
       }
     },
@@ -995,6 +1535,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Error"
@@ -1010,6 +1556,12 @@
             "state": "translated",
             "value": "Export Failed"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportación fallida"
+          }
         }
       }
     },
@@ -1020,6 +1572,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Export Logs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar registros"
           }
         }
       }
@@ -1032,6 +1590,12 @@
             "state": "translated",
             "value": "Export Reader Logs"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar registros del lector"
+          }
         }
       }
     },
@@ -1042,6 +1606,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fetching Streams"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obteniendo transmisiones"
           }
         }
       }
@@ -1054,6 +1624,12 @@
             "state": "translated",
             "value": "Filter Settings"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de filtro"
+          }
         }
       }
     },
@@ -1061,6 +1637,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Global"
@@ -1076,6 +1658,12 @@
             "state": "translated",
             "value": "Global follows the Home Layout orientation. Automatic picks poster or landscape per item."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global sigue la orientación del Diseño de Inicio. Automático elige póster u horizontal según el elemento."
+          }
         }
       }
     },
@@ -1086,6 +1674,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Health check pending"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificación de estado pendiente"
           }
         }
       }
@@ -1098,6 +1692,12 @@
             "state": "translated",
             "value": "Help support the app. Any amount helps keep the app free for everyone"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayuda a apoyar la app. Cualquier cantidad ayuda a mantenerla gratuita para todos"
+          }
         }
       }
     },
@@ -1108,6 +1708,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Help support the app. Any amount helps keep the app free for everyone. Thanks for using the app and supporting development!"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayuda a apoyar la app. Cualquier cantidad ayuda a mantenerla gratuita para todos. ¡Gracias por usar la app y apoyar su desarrollo!"
           }
         }
       }
@@ -1120,6 +1726,12 @@
             "state": "translated",
             "value": "Hero"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destacado"
+          }
         }
       }
     },
@@ -1130,6 +1742,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hide Splash Screen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar pantalla de bienvenida"
           }
         }
       }
@@ -1142,6 +1760,12 @@
             "state": "translated",
             "value": "Higher"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más alto"
+          }
         }
       }
     },
@@ -1152,6 +1776,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Highest"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más alto"
           }
         }
       }
@@ -1164,6 +1794,12 @@
             "state": "translated",
             "value": "Home"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicio"
+          }
         }
       }
     },
@@ -1175,16 +1811,11 @@
             "state": "translated",
             "value": "Home Layout"
           }
-        }
-      }
-    },
-    "iCloud Sync": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "iCloud Sync"
+            "value": "Diseño de inicio"
           }
         }
       }
@@ -1197,6 +1828,12 @@
             "state": "translated",
             "value": "Import"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar"
+          }
         }
       }
     },
@@ -1207,6 +1844,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Import AniList Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar biblioteca de AniList"
           }
         }
       }
@@ -1219,6 +1862,12 @@
             "state": "translated",
             "value": "Import MAL Library"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar biblioteca de MAL"
+          }
         }
       }
     },
@@ -1229,6 +1878,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Import MAL lists as Eclipse collections and reader progress"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa listas de MAL como colecciones de Eclipse y progreso de lectura"
           }
         }
       }
@@ -1241,6 +1896,12 @@
             "state": "translated",
             "value": "Import Trakt Library"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar biblioteca de Trakt"
+          }
         }
       }
     },
@@ -1251,6 +1912,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Import your Watching, Planning, and Completed lists as collections"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa tus listas de Viendo, Planeando y Completado como colecciones"
           }
         }
       }
@@ -1263,6 +1930,12 @@
             "state": "translated",
             "value": "Import your watchlist and watched progress as collections"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa tu lista de seguimiento y progreso visto como colecciones"
+          }
         }
       }
     },
@@ -1273,6 +1946,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Informations Language"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma de la información"
           }
         }
       }
@@ -1285,6 +1964,12 @@
             "state": "translated",
             "value": "Interface & Scope"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interfaz y alcance"
+          }
         }
       }
     },
@@ -1295,6 +1980,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "JSON URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL de JSON"
           }
         }
       }
@@ -1307,6 +1998,12 @@
             "state": "translated",
             "value": "Language"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma"
+          }
         }
       }
     },
@@ -1317,6 +2014,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Large sync: Eclipse will show progress, honor rate limits, and keep this sheet open until it finishes or you cancel."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización grande: Eclipse mostrará el progreso, respetará los límites de solicitudes y mantendrá esta ventana abierta hasta que termine o la canceles."
           }
         }
       }
@@ -1329,6 +2032,12 @@
             "state": "translated",
             "value": "Legal & Source"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legal y código fuente"
+          }
         }
       }
     },
@@ -1339,6 +2048,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biblioteca"
           }
         }
       }
@@ -1351,6 +2066,12 @@
             "state": "translated",
             "value": "Live Trakt Scrobbling"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scrobbling en vivo de Trakt"
+          }
         }
       }
     },
@@ -1361,6 +2082,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Loading amazing content..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando contenido increíble..."
           }
         }
       }
@@ -1373,6 +2100,12 @@
             "state": "translated",
             "value": "Loading episodes..."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando episodios..."
+          }
         }
       }
     },
@@ -1383,6 +2116,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Loading settings..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando ajustes..."
           }
         }
       }
@@ -1395,6 +2134,12 @@
             "state": "translated",
             "value": "Loading..."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando..."
+          }
         }
       }
     },
@@ -1402,6 +2147,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Local"
@@ -1417,6 +2168,12 @@
             "state": "translated",
             "value": "Logger"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registro"
+          }
         }
       }
     },
@@ -1427,6 +2184,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lower"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más bajo"
           }
         }
       }
@@ -1439,6 +2202,12 @@
             "state": "translated",
             "value": "Lowest"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más bajo"
+          }
         }
       }
     },
@@ -1450,38 +2219,11 @@
             "state": "translated",
             "value": "Manual Select"
           }
-        }
-      }
-    },
-    "Mark as Not Watched": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mark as Not Watched"
-          }
-        }
-      }
-    },
-    "Mark as Unwatched": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mark as Unwatched"
-          }
-        }
-      }
-    },
-    "Mark as Watched": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mark as Watched"
+            "value": "Selección manual"
           }
         }
       }
@@ -1494,6 +2236,12 @@
             "state": "translated",
             "value": "Mark Previous as Not Watched"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar anteriores como no vistos"
+          }
         }
       }
     },
@@ -1504,6 +2252,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mark Previous as Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar anteriores como vistos"
+          }
+        }
+      }
+    },
+    "Mark as Not Watched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark as Not Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar como no visto"
+          }
+        }
+      }
+    },
+    "Mark as Unwatched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark as Unwatched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar como no visto"
+          }
+        }
+      }
+    },
+    "Mark as Watched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark as Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar como visto"
           }
         }
       }
@@ -1516,6 +2321,12 @@
             "state": "translated",
             "value": "Matching Algorithm"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algoritmo de coincidencia"
+          }
         }
       }
     },
@@ -1526,6 +2337,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Media Detail Page"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página de detalle multimedia"
           }
         }
       }
@@ -1538,6 +2355,12 @@
             "state": "translated",
             "value": "Media Player"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproductor multimedia"
+          }
         }
       }
     },
@@ -1548,6 +2371,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Medium"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medio"
           }
         }
       }
@@ -1560,6 +2389,12 @@
             "state": "translated",
             "value": "Message"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensaje"
+          }
         }
       }
     },
@@ -1570,6 +2405,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moderno"
           }
         }
       }
@@ -1582,6 +2423,12 @@
             "state": "translated",
             "value": "Movies"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Películas"
+          }
         }
       }
     },
@@ -1592,6 +2439,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Multi Gradient"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Multidegradado"
           }
         }
       }
@@ -1604,6 +2457,12 @@
             "state": "translated",
             "value": "Network"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red"
+          }
         }
       }
     },
@@ -1614,6 +2473,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "New Addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva URL de addon"
           }
         }
       }
@@ -1626,6 +2491,12 @@
             "state": "translated",
             "value": "New Collection"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva colección"
+          }
         }
       }
     },
@@ -1636,6 +2507,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No Active Services"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin servicios activos"
           }
         }
       }
@@ -1648,60 +2525,11 @@
             "state": "translated",
             "value": "No Active Sources"
           }
-        }
-      }
-    },
-    "No episodes scheduled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No episodes scheduled"
-          }
-        }
-      }
-    },
-    "No items in this collection": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No items in this collection"
-          }
-        }
-      }
-    },
-    "No plugin providers installed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No plugin providers installed"
-          }
-        }
-      }
-    },
-    "No plugin repositories installed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No plugin repositories installed"
-          }
-        }
-      }
-    },
-    "No results found": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No results found"
+            "value": "Sin fuentes activas"
           }
         }
       }
@@ -1714,16 +2542,11 @@
             "state": "translated",
             "value": "No Services"
           }
-        }
-      }
-    },
-    "No services or addons installed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No services or addons installed"
+            "value": "Sin servicios"
           }
         }
       }
@@ -1736,6 +2559,12 @@
             "state": "translated",
             "value": "No Settings Available"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay ajustes disponibles"
+          }
         }
       }
     },
@@ -1746,6 +2575,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No Subtitles"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin subtítulos"
           }
         }
       }
@@ -1758,6 +2593,114 @@
             "state": "translated",
             "value": "No TMDB Entry"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin entrada de TMDB"
+          }
+        }
+      }
+    },
+    "No episodes scheduled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No episodes scheduled"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay episodios programados"
+          }
+        }
+      }
+    },
+    "No items in this collection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No items in this collection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay elementos en esta colección"
+          }
+        }
+      }
+    },
+    "No plugin providers installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No plugin providers installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay proveedores de plugins instalados"
+          }
+        }
+      }
+    },
+    "No plugin repositories installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No plugin repositories installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay repositorios de plugins instalados"
+          }
+        }
+      }
+    },
+    "No results found": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No results found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron resultados"
+          }
+        }
+      }
+    },
+    "No services or addons installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No services or addons installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay servicios ni addons instalados"
+          }
         }
       }
     },
@@ -1769,6 +2712,12 @@
             "state": "translated",
             "value": "None"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguno"
+          }
         }
       }
     },
@@ -1776,6 +2725,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Normal"
@@ -1791,16 +2746,11 @@
             "state": "translated",
             "value": "Not searched"
           }
-        }
-      }
-    },
-    "Off follows the global size. Widget rows support size only.": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Off follows the global size. Widget rows support size only."
+            "value": "No buscado"
           }
         }
       }
@@ -1813,6 +2763,29 @@
             "state": "translated",
             "value": "OK"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
+          }
+        }
+      }
+    },
+    "Off follows the global size. Widget rows support size only.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off follows the global size. Widget rows support size only."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivado sigue el tamaño global. Las filas de widgets solo admiten tamaño."
+          }
         }
       }
     },
@@ -1823,6 +2796,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Optional"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcional"
           }
         }
       }
@@ -1835,6 +2814,12 @@
             "state": "translated",
             "value": "Orientation"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientación"
+          }
         }
       }
     },
@@ -1845,6 +2830,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Others"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otros"
           }
         }
       }
@@ -1857,6 +2848,12 @@
             "state": "translated",
             "value": "Palette"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paleta"
+          }
         }
       }
     },
@@ -1867,6 +2864,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Paste the new configured addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pega la nueva URL del addon configurado"
           }
         }
       }
@@ -1879,6 +2882,12 @@
             "state": "translated",
             "value": "Pause"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar"
+          }
         }
       }
     },
@@ -1889,6 +2898,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pause All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar todo"
           }
         }
       }
@@ -1901,6 +2916,12 @@
             "state": "translated",
             "value": "Per Catalog"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por catálogo"
+          }
         }
       }
     },
@@ -1911,6 +2932,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Performance Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de rendimiento"
           }
         }
       }
@@ -1923,6 +2950,12 @@
             "state": "translated",
             "value": "Play"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducir"
+          }
         }
       }
     },
@@ -1930,6 +2963,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plugins"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Plugins"
@@ -1945,6 +2984,12 @@
             "state": "translated",
             "value": "Preview"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista previa"
+          }
         }
       }
     },
@@ -1955,6 +3000,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Preview imports, pushes, and AniList/MAL ports"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista previa de importaciones, envíos y migraciones de AniList/MAL"
           }
         }
       }
@@ -1967,6 +3018,12 @@
             "state": "translated",
             "value": "Quality"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calidad"
+          }
         }
       }
     },
@@ -1977,6 +3034,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Quality Threshold"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbral de calidad"
           }
         }
       }
@@ -1989,6 +3052,12 @@
             "state": "translated",
             "value": "Rating & Notes"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calificación y notas"
+          }
         }
       }
     },
@@ -1999,6 +3068,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reachable"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcanzable"
           }
         }
       }
@@ -2011,6 +3086,12 @@
             "state": "translated",
             "value": "Reader Logs"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros del lector"
+          }
         }
       }
     },
@@ -2021,6 +3102,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Recalculate cache size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recalcular tamaño de caché"
           }
         }
       }
@@ -2033,6 +3120,12 @@
             "state": "translated",
             "value": "Recent Searches"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Búsquedas recientes"
+          }
         }
       }
     },
@@ -2043,6 +3136,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reconfigure Addon"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconfigurar addon"
           }
         }
       }
@@ -2055,6 +3154,12 @@
             "state": "translated",
             "value": "Reconfigure Error"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al reconfigurar"
+          }
         }
       }
     },
@@ -2065,6 +3170,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Remove"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar"
           }
         }
       }
@@ -2077,6 +3188,12 @@
             "state": "translated",
             "value": "Remove Download"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar descarga"
+          }
         }
       }
     },
@@ -2087,6 +3204,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Repository URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del repositorio"
           }
         }
       }
@@ -2099,6 +3222,12 @@
             "state": "translated",
             "value": "Requires MoltenVK MPV"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requiere MoltenVK MPV"
+          }
         }
       }
     },
@@ -2109,6 +3238,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reset All Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer todos los catálogos"
           }
         }
       }
@@ -2121,6 +3256,12 @@
             "state": "translated",
             "value": "Reset Appearance"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer apariencia"
+          }
         }
       }
     },
@@ -2131,6 +3272,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reset Media Detail Layout"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer diseño de detalle multimedia"
           }
         }
       }
@@ -2143,6 +3290,12 @@
             "state": "translated",
             "value": "Reset Progress"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer progreso"
+          }
         }
       }
     },
@@ -2153,6 +3306,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reset to Global"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer a global"
           }
         }
       }
@@ -2165,6 +3324,12 @@
             "state": "translated",
             "value": "Resets theme, layout and per-catalog overrides to their defaults."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablece el tema, el diseño y las anulaciones por catálogo a sus valores predeterminados."
+          }
         }
       }
     },
@@ -2175,6 +3340,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Resets theme, layout, app experience, and per-catalog overrides to their defaults."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablece el tema, el diseño, la experiencia de la app y las anulaciones por catálogo a sus valores predeterminados."
           }
         }
       }
@@ -2187,6 +3358,12 @@
             "state": "translated",
             "value": "Restart Required"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requiere reiniciar"
+          }
         }
       }
     },
@@ -2197,6 +3374,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restart required to apply the interface change"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requiere reiniciar para aplicar el cambio de interfaz"
           }
         }
       }
@@ -2209,6 +3392,12 @@
             "state": "translated",
             "value": "Restore"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar"
+          }
         }
       }
     },
@@ -2219,6 +3408,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restore Confirmation"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar restauración"
           }
         }
       }
@@ -2231,6 +3426,12 @@
             "state": "translated",
             "value": "Restore the default order and visibility."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaura el orden y la visibilidad predeterminados."
+          }
         }
       }
     },
@@ -2241,6 +3442,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restore the default theme and layout values."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaura los valores predeterminados de tema y diseño."
           }
         }
       }
@@ -2253,6 +3460,12 @@
             "state": "translated",
             "value": "Restore the default theme, layout, animation, and startup display values."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaura los valores predeterminados de tema, diseño, animación y pantalla de inicio."
+          }
         }
       }
     },
@@ -2263,6 +3476,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Resume"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar"
           }
         }
       }
@@ -2275,6 +3494,12 @@
             "state": "translated",
             "value": "Resume All"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar todo"
+          }
         }
       }
     },
@@ -2285,6 +3510,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Retry"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintentar"
           }
         }
       }
@@ -2297,6 +3528,12 @@
             "state": "translated",
             "value": "Retry Failed"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintento fallido"
+          }
         }
       }
     },
@@ -2307,6 +3544,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Review"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reseña"
           }
         }
       }
@@ -2319,6 +3562,12 @@
             "state": "translated",
             "value": "Rows set to Global follow the settings above. Orientation applies to standard poster rows; widget rows support size only."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las filas configuradas como Global siguen los ajustes anteriores. La orientación aplica a las filas de pósters estándar; las filas de widgets solo admiten tamaño."
+          }
         }
       }
     },
@@ -2329,6 +3578,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Run"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar"
           }
         }
       }
@@ -2341,6 +3596,12 @@
             "state": "translated",
             "value": "Run Sync Tool?"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Ejecutar herramienta de sincronización?"
+          }
         }
       }
     },
@@ -2351,6 +3612,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Save"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
           }
         }
       }
@@ -2363,6 +3630,12 @@
             "state": "translated",
             "value": "Schedule"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calendario"
+          }
         }
       }
     },
@@ -2373,6 +3646,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Search"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
           }
         }
       }
@@ -2385,6 +3664,12 @@
             "state": "translated",
             "value": "Search Movies & TV Shows"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar películas y series"
+          }
         }
       }
     },
@@ -2395,6 +3680,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Search..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcador de posición de búsqueda"
           }
         }
       }
@@ -2407,6 +3698,12 @@
             "state": "translated",
             "value": "Searching for:"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando:"
+          }
         }
       }
     },
@@ -2417,6 +3714,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Searching..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando..."
           }
         }
       }
@@ -2429,6 +3732,12 @@
             "state": "translated",
             "value": "Seasons"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temporadas"
+          }
         }
       }
     },
@@ -2439,6 +3748,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Services"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servicios"
           }
         }
       }
@@ -2451,6 +3766,12 @@
             "state": "translated",
             "value": "Services & Addons"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servicios y addons"
+          }
         }
       }
     },
@@ -2461,6 +3782,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
           }
         }
       }
@@ -2473,6 +3800,12 @@
             "state": "translated",
             "value": "Settings Saved"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes guardados"
+          }
         }
       }
     },
@@ -2484,16 +3817,11 @@
             "state": "translated",
             "value": "Share"
           }
-        }
-      }
-    },
-    "Shows": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Shows"
+            "value": "Compartir"
           }
         }
       }
@@ -2506,6 +3834,29 @@
             "state": "translated",
             "value": "Show ambient motion behind the home screen."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra movimiento ambiental detrás de la pantalla de inicio."
+          }
+        }
+      }
+    },
+    "Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Series"
+          }
         }
       }
     },
@@ -2516,6 +3867,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño"
           }
         }
       }
@@ -2528,6 +3885,12 @@
             "state": "translated",
             "value": "Size and orientation of home rows - globally or per catalog."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño y orientación de las filas de inicio, de forma global o por catálogo."
+          }
         }
       }
     },
@@ -2538,6 +3901,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Skip"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitir"
           }
         }
       }
@@ -2550,6 +3919,12 @@
             "state": "translated",
             "value": "Skip Episode"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitir episodio"
+          }
         }
       }
     },
@@ -2560,6 +3935,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Skip the launch splash once Eclipse opens."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omite la pantalla de bienvenida al abrir Eclipse."
           }
         }
       }
@@ -2572,6 +3953,12 @@
             "state": "translated",
             "value": "Solid Color"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color sólido"
+          }
         }
       }
     },
@@ -2582,6 +3969,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sort"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordenar"
           }
         }
       }
@@ -2594,6 +3987,12 @@
             "state": "translated",
             "value": "Specials & OVAs"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Especiales y OVAs"
+          }
         }
       }
     },
@@ -2604,6 +4003,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Stay here while this large sync runs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permanece aquí mientras se ejecuta esta sincronización grande"
           }
         }
       }
@@ -2616,6 +4021,12 @@
             "state": "translated",
             "value": "Storage"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento"
+          }
         }
       }
     },
@@ -2626,6 +4037,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Stream Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de transmisión"
           }
         }
       }
@@ -2638,6 +4055,12 @@
             "state": "translated",
             "value": "Stremio Error"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de Stremio"
+          }
         }
       }
     },
@@ -2649,16 +4072,11 @@
             "state": "translated",
             "value": "Support"
           }
-        }
-      }
-    },
-    "Switch to Reader Mode": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Switch to Reader Mode"
+            "value": "Soporte"
           }
         }
       }
@@ -2671,6 +4089,29 @@
             "state": "translated",
             "value": "Switch Mode Animation"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animación al cambiar de modo"
+          }
+        }
+      }
+    },
+    "Switch to Reader Mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch to Reader Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar a modo Lector"
+          }
         }
       }
     },
@@ -2681,6 +4122,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sync Tools"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramientas de sincronización"
           }
         }
       }
@@ -2693,6 +4140,12 @@
             "state": "translated",
             "value": "The interface style is applied when Eclipse launches. Restart the app to switch between the Modern and Classic layouts."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estilo de interfaz se aplica cuando Eclipse se inicia. Reinicia la app para cambiar entre los diseños Moderno y Clásico."
+          }
         }
       }
     },
@@ -2703,6 +4156,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "The service settings have been updated successfully."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los ajustes del servicio se actualizaron correctamente."
           }
         }
       }
@@ -2715,6 +4174,12 @@
             "state": "translated",
             "value": "Theme"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema"
+          }
         }
       }
     },
@@ -2725,6 +4190,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "These apply to every home row. Override individual rows below."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estos se aplican a todas las filas de inicio. Anúlalos individualmente por fila más abajo."
           }
         }
       }
@@ -2737,6 +4208,12 @@
             "state": "translated",
             "value": "Thick"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grueso"
+          }
         }
       }
     },
@@ -2747,6 +4224,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Thin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delgado"
           }
         }
       }
@@ -2759,6 +4242,12 @@
             "state": "translated",
             "value": "This downloaded episode will be permanently removed."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este episodio descargado se eliminará permanentemente."
+          }
         }
       }
     },
@@ -2769,6 +4258,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This program comes with no warranty, to the extent permitted by law."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este programa no ofrece garantía alguna, en la medida permitida por la ley."
           }
         }
       }
@@ -2781,6 +4276,12 @@
             "state": "translated",
             "value": "This service doesn't have configurable settings."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este servicio no tiene ajustes configurables."
+          }
         }
       }
     },
@@ -2791,6 +4292,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will cancel all active downloads and remove all downloaded files. This action cannot be undone."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto cancelará todas las descargas activas y eliminará todos los archivos descargados. Esta acción no se puede deshacer."
           }
         }
       }
@@ -2803,6 +4310,12 @@
             "state": "translated",
             "value": "This will import your AniList lists as Eclipse collections and fill local watch/read progress without deleting or downgrading anything."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto importará tus listas de AniList como colecciones de Eclipse y completará el progreso local de visualización/lectura sin eliminar ni retroceder nada."
+          }
         }
       }
     },
@@ -2813,6 +4326,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will import your MAL lists as Eclipse collections and fill local watch/read progress without deleting or downgrading anything."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto importará tus listas de MAL como colecciones de Eclipse y completará el progreso local de visualización/lectura sin eliminar ni retroceder nada."
           }
         }
       }
@@ -2825,6 +4344,12 @@
             "state": "translated",
             "value": "This will import your Trakt watchlist and watched progress as Eclipse collections without deleting or downgrading anything."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto importará tu lista de seguimiento y progreso visto de Trakt como colecciones de Eclipse sin eliminar ni retroceder nada."
+          }
         }
       }
     },
@@ -2835,6 +4360,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will overwrite your current settings, collections, watch progress, tracker logins including MAL, and service configurations with the backup data. Continue?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto sobrescribirá tus ajustes actuales, colecciones, progreso de visualización, inicios de sesión de rastreadores (incluido MAL) y configuraciones de servicios con los datos de la copia de seguridad. ¿Continuar?"
           }
         }
       }
@@ -2847,6 +4378,12 @@
             "state": "translated",
             "value": "This will remove all completed download files. This action cannot be undone."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto eliminará todos los archivos de descargas completadas. Esta acción no se puede deshacer."
+          }
         }
       }
     },
@@ -2857,6 +4394,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will remove cached files. You may need to re-download some content later."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto eliminará los archivos en caché. Es posible que debas volver a descargar algún contenido más adelante."
           }
         }
       }
@@ -2869,6 +4412,12 @@
             "state": "translated",
             "value": "This writes progress to the selected destination but never deletes entries or downgrades progress."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto escribe el progreso en el destino seleccionado, pero nunca elimina entradas ni retrocede el progreso."
+          }
         }
       }
     },
@@ -2879,6 +4428,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Threshold (0.0 - 1.0)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbral (0.0 - 1.0)"
           }
         }
       }
@@ -2891,6 +4446,12 @@
             "state": "translated",
             "value": "Timezone"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zona horaria"
+          }
         }
       }
     },
@@ -2901,6 +4462,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Trackers"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rastreadores"
           }
         }
       }
@@ -2913,71 +4480,11 @@
             "state": "translated",
             "value": "Trakt Features"
           }
-        }
-      }
-    },
-    "Trakt list URL or ID": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trakt list URL or ID"
-          }
-        }
-      }
-    },
-    "Trakt Public Catalogs": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trakt Public Catalogs"
-          }
-        }
-      }
-    },
-    "Trakt Reviews": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trakt Reviews"
-          }
-        }
-      }
-    },
-    "Try adjusting your filter or search for something else": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try adjusting your filter or search for something else"
-          }
-        }
-      }
-    },
-    "Try Again": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try Again"
-          }
-        }
-      }
-    },
-    "Try searching for a different movie or TV show": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try searching for a different movie or TV show"
+            "value": "Funciones de Trakt"
           }
         }
       }
@@ -2990,6 +4497,114 @@
             "state": "translated",
             "value": "Type"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo de lista de Trakt"
+          }
+        }
+      }
+    },
+    "Trakt Public Catalogs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trakt Public Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogos públicos de Trakt"
+          }
+        }
+      }
+    },
+    "Trakt Reviews": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trakt Reviews"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reseñas de Trakt"
+          }
+        }
+      }
+    },
+    "Trakt list URL or ID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trakt list URL or ID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL o ID de lista de Trakt"
+          }
+        }
+      }
+    },
+    "Try Again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try Again"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intentar de nuevo"
+          }
+        }
+      }
+    },
+    "Try adjusting your filter or search for something else": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try adjusting your filter or search for something else"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intenta ajustar el filtro o busca otra cosa"
+          }
+        }
+      }
+    },
+    "Try searching for a different movie or TV show": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try searching for a different movie or TV show"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intenta buscar otra película o serie"
+          }
         }
       }
     },
@@ -3000,6 +4615,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Update URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar URL"
           }
         }
       }
@@ -3012,6 +4633,12 @@
             "state": "translated",
             "value": "View"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver"
+          }
         }
       }
     },
@@ -3022,6 +4649,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Watch Now"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver ahora"
           }
         }
       }
@@ -3034,6 +4667,12 @@
             "state": "translated",
             "value": "You don't have any active services, Stremio addons, or plugins. Add or enable a source in Settings."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tienes servicios activos, addons de Stremio ni plugins. Agrega o activa una fuente en Ajustes."
+          }
         }
       }
     },
@@ -3045,6 +4684,29 @@
             "state": "translated",
             "value": "You don't have any active services. Please go to the Services tab to download and activate services."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tienes servicios activos. Ve a la pestaña Servicios para descargar y activar servicios."
+          }
+        }
+      }
+    },
+    "iCloud Sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización con iCloud"
+          }
         }
       }
     },
@@ -3055,6 +4717,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Visto"
           }
         }
       }

--- a/Eclipse/Localizable.xcstrings
+++ b/Eclipse/Localizable.xcstrings
@@ -1,6 +1,91 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "A PIN can be set once the profile exists.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A PIN can be set once the profile exists."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se puede configurar un PIN una vez que el perfil exista."
+          }
+        }
+      }
+    },
+    "A new Eclipse release is available on GitHub.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A new Eclipse release is available on GitHub."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hay una nueva versión de Eclipse disponible en GitHub."
+          }
+        }
+      }
+    },
+    "A player and a catalog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A player and a catalog."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un reproductor y un catálogo."
+          }
+        }
+      }
+    },
+    "A sync recovery point is waiting to finish. Cloud uploads stay paused until Eclipse completes it, usually at the next app activation.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A sync recovery point is waiting to finish. Cloud uploads stay paused until Eclipse completes it, usually at the next app activation."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hay un punto de recuperación de sincronización pendiente de terminar. Las subidas a la nube quedan pausadas hasta que Eclipse lo complete, normalmente en la siguiente activación de la app."
+          }
+        }
+      }
+    },
+    "About": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acerca de"
+          }
+        }
+      }
+    },
     "Accent Color": {
       "extractionState": "manual",
       "localizations": {
@@ -8,6 +93,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Accent Color"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de acento"
           }
         }
       }
@@ -20,6 +111,12 @@
             "state": "translated",
             "value": "Activate at least one stream-capable service, addon, or plugin to use Auto Mode."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa al menos un servicio, addon o plugin compatible con transmisión para usar el Modo Automático."
+          }
         }
       }
     },
@@ -30,6 +127,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Add"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar"
+          }
+        }
+      }
+    },
+    "Add Nuvio Plugin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Nuvio Plugin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar plugin de Nuvio"
           }
         }
       }
@@ -42,6 +162,46 @@
             "state": "translated",
             "value": "Add Service"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar servicio"
+          }
+        }
+      }
+    },
+    "Add SkyStream Plugin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add SkyStream Plugin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar plugin de SkyStream"
+          }
+        }
+      }
+    },
+    "Add Source": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Source"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar fuente"
+          }
         }
       }
     },
@@ -52,6 +212,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Add Stremio Addon"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar addon de Stremio"
+          }
+        }
+      }
+    },
+    "Add a source": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a source"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar una fuente"
           }
         }
       }
@@ -64,6 +247,12 @@
             "state": "translated",
             "value": "Add to Collection"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar a la colección"
+          }
         }
       }
     },
@@ -74,6 +263,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Added lists appear in Catalogs for ordering and per-row toggles."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las listas agregadas aparecen en Catálogos para ordenarlas y activarlas por fila."
           }
         }
       }
@@ -86,6 +281,12 @@
             "state": "translated",
             "value": "Addon URL"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del addon"
+          }
         }
       }
     },
@@ -97,16 +298,79 @@
             "state": "translated",
             "value": "Affects buttons, links and other interactive elements."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afecta botones, enlaces y otros elementos interactivos."
+          }
         }
       }
     },
-    "Animated Background": {
+    "Already use Eclipse?": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Animated Background"
+            "value": "Already use Eclipse?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Ya usas Eclipse?"
+          }
+        }
+      }
+    },
+    "AniList": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList"
+          }
+        }
+      }
+    },
+    "AniList Unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList Unavailable"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList no disponible"
+          }
+        }
+      }
+    },
+    "AniList appears to be down. Eclipse is switching to MyAnimeList fallback for anime metadata. Season and special mapping should still work, but may be less accurate until AniList recovers.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList appears to be down. Eclipse is switching to MyAnimeList fallback for anime metadata. Season and special mapping should still work, but may be less accurate until AniList recovers."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList parece estar caído. Eclipse está cambiando a MyAnimeList como respaldo para los metadatos de anime. El mapeo de temporadas y especiales debería seguir funcionando, pero puede ser menos preciso hasta que AniList se recupere."
           }
         }
       }
@@ -119,6 +383,29 @@
             "state": "translated",
             "value": "Animate the top-right Media and Reader mode switch."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anima el interruptor de modo Media/Lector de la esquina superior derecha."
+          }
+        }
+      }
+    },
+    "Animated Background": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animated Background"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondo animado"
+          }
         }
       }
     },
@@ -129,6 +416,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "App Experience"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experiencia de la app"
           }
         }
       }
@@ -141,6 +434,12 @@
             "state": "translated",
             "value": "App Updates"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones de la app"
+          }
         }
       }
     },
@@ -151,6 +450,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "Appearance"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apariencia"
+          }
+        }
+      }
+    },
+    "Apply Extra Rules To": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply Extra Rules To"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar reglas adicionales a"
+          }
+        }
+      }
+    },
+    "Apply to All Connected Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply to All Connected Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar a todas las fuentes conectadas"
+          }
+        }
+      }
+    },
+    "Apply to Home Screen": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply to Home Screen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar a la pantalla de inicio"
           }
         }
       }
@@ -163,6 +519,46 @@
             "state": "translated",
             "value": "Ascending"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ascendente"
+          }
+        }
+      }
+    },
+    "Assume Original Language for Untagged Streams": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assume Original Language for Untagged Streams"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asumir idioma original para transmisiones sin etiquetar"
+          }
+        }
+      }
+    },
+    "At least one grown-up profile has to stay. Kids profiles can't add, edit, or delete profiles, so turning this one into a kids profile would leave nobody able to change it back.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "At least one grown-up profile has to stay. Kids profiles can't add, edit, or delete profiles, so turning this one into a kids profile would leave nobody able to change it back."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debe quedar al menos un perfil de adulto. Los perfiles infantiles no pueden agregar, editar ni eliminar perfiles, así que convertir este en perfil infantil dejaría a nadie que pudiera revertirlo."
+          }
         }
       }
     },
@@ -173,6 +569,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auto Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo automático"
+          }
+        }
+      }
+    },
+    "Auto Mode Error Intelligence": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Mode Error Intelligence"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inteligencia de errores del modo automático"
+          }
+        }
+      }
+    },
+    "Auto Mode checks included, enabled sources from top to bottom. Drag to set priority. Include All and Exclude All also update installed sources that are currently disabled on this device, without changing sources that exist only on another platform.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Mode checks included, enabled sources from top to bottom. Drag to set priority. Include All and Exclude All also update installed sources that are currently disabled on this device, without changing sources that exist only on another platform."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El modo automático revisa las fuentes incluidas y activadas de arriba hacia abajo. Arrastra para establecer la prioridad. Incluir todo y Excluir todo también actualizan las fuentes instaladas que están desactivadas en este dispositivo, sin cambiar las fuentes que solo existen en otra plataforma."
+          }
+        }
+      }
+    },
+    "Auto Mode checks included, enabled sources from top to bottom. Use the arrow buttons to set priority. Include All and Exclude All also update installed sources that are currently disabled on this Apple TV, without changing sources that exist only on another platform.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Mode checks included, enabled sources from top to bottom. Use the arrow buttons to set priority. Include All and Exclude All also update installed sources that are currently disabled on this Apple TV, without changing sources that exist only on another platform."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El modo automático revisa las fuentes incluidas y activadas de arriba hacia abajo. Usa los botones de flecha para establecer la prioridad. Incluir todo y Excluir todo también actualizan las fuentes instaladas que están desactivadas en este Apple TV, sin cambiar las fuentes que solo existen en otra plataforma."
           }
         }
       }
@@ -185,6 +638,12 @@
             "state": "translated",
             "value": "Auto Quality"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calidad automática"
+          }
         }
       }
     },
@@ -196,16 +655,11 @@
             "state": "translated",
             "value": "Auto Sync Ratings"
           }
-        }
-      }
-    },
-    "Auto-check GitHub Releases": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auto-check GitHub Releases"
+            "value": "Sincronizar calificaciones automáticamente"
           }
         }
       }
@@ -218,6 +672,29 @@
             "state": "translated",
             "value": "Auto-Select Episodes"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selección automática de episodios"
+          }
+        }
+      }
+    },
+    "Auto-Select Episodes also applies when choosing a source manually.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Select Episodes also applies when choosing a source manually."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La selección automática de episodios también aplica al elegir una fuente manualmente."
+          }
         }
       }
     },
@@ -228,6 +705,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auto-Select Episodes also applies when choosing a source manually. Auto Mode checks enabled sources from top to bottom. Drag to set priority, and turn Auto Quality off when you want to choose stream quality yourself."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La selección automática de episodios también aplica al elegir una fuente manualmente. El Modo Automático revisa las fuentes activadas de arriba hacia abajo. Arrastra para establecer la prioridad y desactiva la Calidad Automática cuando quieras elegir tú mismo la calidad de la transmisión."
           }
         }
       }
@@ -240,6 +723,46 @@
             "state": "translated",
             "value": "Auto-Update Services"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar servicios automáticamente"
+          }
+        }
+      }
+    },
+    "Auto-Update Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Update Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar fuentes automáticamente"
+          }
+        }
+      }
+    },
+    "Auto-check GitHub Releases": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-check GitHub Releases"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar lanzamientos de GitHub automáticamente"
+          }
         }
       }
     },
@@ -250,6 +773,114 @@
           "stringUnit": {
             "state": "translated",
             "value": "Automatically check for service updates when the app is opened."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busca actualizaciones de servicios automáticamente al abrir la app."
+          }
+        }
+      }
+    },
+    "Automatically check for source updates when the app is opened.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically check for source updates when the app is opened."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busca actualizaciones de fuentes automáticamente al abrir la app."
+          }
+        }
+      }
+    },
+    "Automatically keep selected Eclipse data in sync through iCloud, Google Drive, or OneDrive.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically keep selected Eclipse data in sync through iCloud, Google Drive, or OneDrive."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantiene los datos seleccionados de Eclipse sincronizados automáticamente mediante iCloud, Google Drive o OneDrive."
+          }
+        }
+      }
+    },
+    "Available": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponible"
+          }
+        }
+      }
+    },
+    "Available only when playing with MPV's MoltenVK renderer. The player button stays hidden in AVPlayer and while this setting is off.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available only when playing with MPV's MoltenVK renderer. The player button stays hidden in AVPlayer and while this setting is off."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponible solo al reproducir con el motor MoltenVK de MPV. El botón del reproductor permanece oculto en AVPlayer y mientras este ajuste esté apagado."
+          }
+        }
+      }
+    },
+    "Back": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrás"
+          }
+        }
+      }
+    },
+    "Back to Library": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back to Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a la biblioteca"
           }
         }
       }
@@ -262,6 +893,12 @@
             "state": "translated",
             "value": "Backup & Import"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia de seguridad e importación"
+          }
         }
       }
     },
@@ -272,6 +909,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Backup & Restore"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia de seguridad y restauración"
           }
         }
       }
@@ -284,6 +927,97 @@
             "state": "translated",
             "value": "Banner color bleeds, then the background takes over"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El color del banner se difumina y luego domina el fondo"
+          }
+        }
+      }
+    },
+    "Behavior": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Behavior"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comportamiento"
+          }
+        }
+      }
+    },
+    "Best-effort stream rules for the selected sources. An Include list only keeps streams with a matching detected language; Exclude takes priority when the same language appears in both lists. When Assume Original Language for Untagged Streams is enabled, a stream with no language data is evaluated using the media's TMDB original language before Include and Exclude rules run. When Treat Dubbed Anime Streams as English is enabled, anime streams labeled dubbed or dub match English filters and count as having language data. Quality and language detection use stream tags, filenames, and labels; a stream URL contributes only its path, and two-letter codes count only when a source reports them as language data.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Best-effort stream rules for the selected sources. An Include list only keeps streams with a matching detected language; Exclude takes priority when the same language appears in both lists. When Assume Original Language for Untagged Streams is enabled, a stream with no language data is evaluated using the media's TMDB original language before Include and Exclude rules run. When Treat Dubbed Anime Streams as English is enabled, anime streams labeled dubbed or dub match English filters and count as having language data. Quality and language detection use stream tags, filenames, and labels; a stream URL contributes only its path, and two-letter codes count only when a source reports them as language data."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reglas de mejor esfuerzo para las transmisiones de las fuentes seleccionadas. Una lista de Incluir solo conserva transmisiones con un idioma detectado que coincida; Excluir tiene prioridad cuando el mismo idioma aparece en ambas listas. Cuando \"Asumir idioma original para transmisiones sin etiquetar\" está activado, una transmisión sin datos de idioma se evalúa usando el idioma original de TMDB antes de aplicar las reglas de Incluir y Excluir. Cuando \"Tratar transmisiones de anime dobladas como inglés\" está activado, las transmisiones de anime etiquetadas como dobladas cuentan como si tuvieran datos de idioma en inglés. La detección de calidad e idioma usa etiquetas, nombres de archivo y etiquetas de la transmisión; una URL de transmisión solo aporta su ruta, y los códigos de dos letras solo cuentan cuando una fuente los reporta como datos de idioma."
+          }
+        }
+      }
+    },
+    "Block Add-on Catalogs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block Add-on Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquear catálogos de addons"
+          }
+        }
+      }
+    },
+    "Block Add-on Subtitles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block Add-on Subtitles"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquear subtítulos de addons"
+          }
+        }
+      }
+    },
+    "Browse": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explorar"
+          }
         }
       }
     },
@@ -294,6 +1028,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cancel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         }
       }
@@ -306,6 +1046,46 @@
             "state": "translated",
             "value": "Cancel All Active"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar todo lo activo"
+          }
+        }
+      }
+    },
+    "Cancel Sign-In": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel Sign-In"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar inicio de sesión"
+          }
+        }
+      }
+    },
+    "Card Info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Card Info"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Información de la tarjeta"
+          }
         }
       }
     },
@@ -316,6 +1096,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cast"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transmitir"
           }
         }
       }
@@ -328,6 +1114,12 @@
             "state": "translated",
             "value": "Catalog name (optional)"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del catálogo (opcional)"
+          }
         }
       }
     },
@@ -338,6 +1130,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogos"
           }
         }
       }
@@ -350,6 +1148,114 @@
             "state": "translated",
             "value": "Category"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categoría"
+          }
+        }
+      }
+    },
+    "Change": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar"
+          }
+        }
+      }
+    },
+    "Changes are blocked": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes are blocked"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los cambios están bloqueados"
+          }
+        }
+      }
+    },
+    "Check for Update": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Update"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualización"
+          }
+        }
+      }
+    },
+    "Checking this title...": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking this title..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificando este título..."
+          }
+        }
+      }
+    },
+    "Choose a day": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a day"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un día"
+          }
+        }
+      }
+    },
+    "Choose a preset with the remote. A custom color synced from another device remains in use until you select a preset.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a preset with the remote. A custom color synced from another device remains in use until you select a preset."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un valor predeterminado con el control remoto. Un color personalizado sincronizado desde otro dispositivo se mantiene en uso hasta que selecciones un valor predeterminado."
+          }
         }
       }
     },
@@ -360,6 +1266,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Choose a server to stream from"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un servidor desde el cual transmitir"
           }
         }
       }
@@ -372,6 +1284,12 @@
             "state": "translated",
             "value": "Choose a subtitle track"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una pista de subtítulos"
+          }
         }
       }
     },
@@ -382,6 +1300,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "Choose an episode:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un episodio:"
+          }
+        }
+      }
+    },
+    "Choose an optional way to support Eclipse.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose an optional way to support Eclipse."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una forma opcional de apoyar a Eclipse."
+          }
+        }
+      }
+    },
+    "Choose how Eclipse automatically selects sources, episodes, and stream quality.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose how Eclipse automatically selects sources, episodes, and stream quality."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige cómo Eclipse selecciona automáticamente fuentes, episodios y calidad de transmisión."
+          }
+        }
+      }
+    },
+    "Choose what Eclipse should check for on this device.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose what Eclipse should check for on this device."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige qué debe verificar Eclipse en este dispositivo."
           }
         }
       }
@@ -394,6 +1369,12 @@
             "state": "translated",
             "value": "Classic"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clásico"
+          }
         }
       }
     },
@@ -404,6 +1385,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Classic Gradient"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Degradado clásico"
           }
         }
       }
@@ -416,6 +1403,29 @@
             "state": "translated",
             "value": "Clear"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
+        }
+      }
+    },
+    "Clear All": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar todo"
+          }
         }
       }
     },
@@ -426,6 +1436,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Clear All Logs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar todos los registros"
           }
         }
       }
@@ -438,6 +1454,46 @@
             "state": "translated",
             "value": "Clear Cache?"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Borrar caché?"
+          }
+        }
+      }
+    },
+    "Clear Excluded Languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Excluded Languages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar idiomas excluidos"
+          }
+        }
+      }
+    },
+    "Clear Included Languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Included Languages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar idiomas incluidos"
+          }
         }
       }
     },
@@ -448,6 +1504,114 @@
           "stringUnit": {
             "state": "translated",
             "value": "Clear Reader Logs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar registros del lector"
+          }
+        }
+      }
+    },
+    "Close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
+          }
+        }
+      }
+    },
+    "Cloud Sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización en la nube"
+          }
+        }
+      }
+    },
+    "Cloud Sync & Cache": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Sync & Cache"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización en la nube y caché"
+          }
+        }
+      }
+    },
+    "Cloud Sync Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Sync Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de sincronización en la nube"
+          }
+        }
+      }
+    },
+    "Cloud Sync starts off. Turning it on stores library, playback progress, TV-safe preferences, supported installed-source configuration, and tracker sign-ins in your private iCloud database. Turning it off stops syncing without deleting either copy. Cloud-provider login tokens, ephemeral playback URLs, and session cookies stay local.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Sync starts off. Turning it on stores library, playback progress, TV-safe preferences, supported installed-source configuration, and tracker sign-ins in your private iCloud database. Turning it off stops syncing without deleting either copy. Cloud-provider login tokens, ephemeral playback URLs, and session cookies stay local."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sincronización en la nube empieza apagada. Activarla guarda la biblioteca, el progreso de reproducción, las preferencias seguras para TV, la configuración de fuentes instaladas compatibles y los inicios de sesión de rastreadores en tu base de datos privada de iCloud. Desactivarla detiene la sincronización sin borrar ninguna de las dos copias. Los tokens de inicio de sesión del proveedor de la nube, las URLs temporales de reproducción y las cookies de sesión permanecen locales."
+          }
+        }
+      }
+    },
+    "Cloud sync is on. \"This Device Only\" turns every cloud provider off on this device before restoring, keeps the complete restored backup here, and leaves the cloud copy and your other devices unchanged. Sync stays off here until you turn a provider on again. \"Replace Everywhere\" keeps your current provider choices and makes this backup authoritative after the restore finishes, replacing newer cloud changes, including progress recorded since the backup was made.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud sync is on. \"This Device Only\" turns every cloud provider off on this device before restoring, keeps the complete restored backup here, and leaves the cloud copy and your other devices unchanged. Sync stays off here until you turn a provider on again. \"Replace Everywhere\" keeps your current provider choices and makes this backup authoritative after the restore finishes, replacing newer cloud changes, including progress recorded since the backup was made."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sincronización en la nube está activada. \\\"Solo este dispositivo\\\" desactiva todos los proveedores de nube en este dispositivo antes de restaurar, conserva aquí la copia de seguridad restaurada completa, y deja sin cambios la copia en la nube y tus otros dispositivos. La sincronización queda apagada aquí hasta que actives un proveedor de nuevo. \\\"Reemplazar en todos lados\\\" conserva tus proveedores actuales y hace que esta copia de seguridad sea la autoritativa después de restaurar, reemplazando cambios más recientes en la nube, incluido el progreso registrado desde que se hizo la copia."
           }
         }
       }
@@ -460,6 +1624,12 @@
             "state": "translated",
             "value": "Collection Name"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre de la colección"
+          }
         }
       }
     },
@@ -467,6 +1637,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color 1"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Color 1"
@@ -482,6 +1658,12 @@
             "state": "translated",
             "value": "Color 2"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color 2"
+          }
         }
       }
     },
@@ -489,6 +1671,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color 3"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Color 3"
@@ -504,6 +1692,12 @@
             "state": "translated",
             "value": "Community"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comunidad"
+          }
         }
       }
     },
@@ -514,6 +1708,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Company"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empresa"
           }
         }
       }
@@ -526,6 +1726,12 @@
             "state": "translated",
             "value": "Configuration"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración"
+          }
         }
       }
     },
@@ -536,6 +1742,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Configure"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar"
           }
         }
       }
@@ -548,6 +1760,12 @@
             "state": "translated",
             "value": "Configure this addon on the web, then use \"Update URL\" to paste the new URL."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configura este addon en la web y luego usa \"Actualizar URL\" para pegar la nueva URL."
+          }
         }
       }
     },
@@ -558,6 +1776,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Configured addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del addon configurado"
+          }
+        }
+      }
+    },
+    "Configured manifest URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configured manifest URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del manifiesto configurado"
+          }
+        }
+      }
+    },
+    "Confirm Code Replacement": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm Code Replacement"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar reemplazo de código"
           }
         }
       }
@@ -570,6 +1828,46 @@
             "state": "translated",
             "value": "Connect"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar"
+          }
+        }
+      }
+    },
+    "Connect Trakt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect Trakt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar Trakt"
+          }
+        }
+      }
+    },
+    "Connect on iPhone or iPad": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect on iPhone or iPad"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar en iPhone o iPad"
+          }
         }
       }
     },
@@ -580,6 +1878,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connection Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de conexión"
+          }
+        }
+      }
+    },
+    "Content Blocking": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Content Blocking"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueo de contenido"
           }
         }
       }
@@ -592,6 +1913,12 @@
             "state": "translated",
             "value": "Content Catalogs"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogos de contenido"
+          }
         }
       }
     },
@@ -602,6 +1929,114 @@
           "stringUnit": {
             "state": "translated",
             "value": "Copy Log Message"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar mensaje del registro"
+          }
+        }
+      }
+    },
+    "Copy Stream URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Stream URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar URL de la transmisión"
+          }
+        }
+      }
+    },
+    "Could not refresh results": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not refresh results"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron actualizar los resultados"
+          }
+        }
+      }
+    },
+    "Couldn't Find a Random Title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't Find a Random Title"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo encontrar un título aleatorio"
+          }
+        }
+      }
+    },
+    "Couldn't Remove Plugin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't Remove Plugin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo quitar el plugin"
+          }
+        }
+      }
+    },
+    "Couldn't Update All Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't Update All Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron actualizar todas las fuentes"
+          }
+        }
+      }
+    },
+    "Could’nt Update History": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could’nt Update History"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo actualizar el historial"
           }
         }
       }
@@ -614,6 +2049,12 @@
             "state": "translated",
             "value": "Create"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear"
+          }
         }
       }
     },
@@ -624,6 +2065,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Create New Collection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear nueva colección"
+          }
+        }
+      }
+    },
+    "Create your profile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create your profile"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea tu perfil"
+          }
+        }
+      }
+    },
+    "Current Color": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current Color"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color actual"
           }
         }
       }
@@ -636,6 +2117,12 @@
             "state": "translated",
             "value": "Custom Background Color"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de fondo personalizado"
+          }
         }
       }
     },
@@ -646,6 +2133,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Custom palette colors blend into a multi-gradient. Pick three."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los colores de la paleta personalizada se combinan en un multidegradado. Elige tres."
           }
         }
       }
@@ -658,6 +2151,29 @@
             "state": "translated",
             "value": "Custom size"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño personalizado"
+          }
+        }
+      }
+    },
+    "Customize": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Customize"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizar"
+          }
         }
       }
     },
@@ -668,6 +2184,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Data"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datos"
+          }
+        }
+      }
+    },
+    "Decrease": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrease"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disminuir"
+          }
+        }
+      }
+    },
+    "Decrease Size": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrease Size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disminuir tamaño"
           }
         }
       }
@@ -680,6 +2236,12 @@
             "state": "translated",
             "value": "Default"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado"
+          }
         }
       }
     },
@@ -690,6 +2252,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Delete"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
           }
         }
       }
@@ -702,6 +2270,12 @@
             "state": "translated",
             "value": "Delete All"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar todo"
+          }
         }
       }
     },
@@ -712,6 +2286,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Delete All Downloads"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar todas las descargas"
           }
         }
       }
@@ -724,6 +2304,12 @@
             "state": "translated",
             "value": "Delete Completed"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar completados"
+          }
         }
       }
     },
@@ -734,6 +2320,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Delete Download"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar descarga"
           }
         }
       }
@@ -746,6 +2338,12 @@
             "state": "translated",
             "value": "Delete Episode"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar episodio"
+          }
         }
       }
     },
@@ -756,6 +2354,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Descending"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descendente"
           }
         }
       }
@@ -768,6 +2372,12 @@
             "state": "translated",
             "value": "Description (optional)"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descripción (opcional)"
+          }
         }
       }
     },
@@ -778,6 +2388,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Detail Pages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Páginas de detalle"
           }
         }
       }
@@ -790,6 +2406,29 @@
             "state": "translated",
             "value": "Details"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles"
+          }
+        }
+      }
+    },
+    "Diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostics"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico"
+          }
         }
       }
     },
@@ -800,6 +2439,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Direction"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección"
+          }
+        }
+      }
+    },
+    "Disable All Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable All Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivar todas las fuentes"
           }
         }
       }
@@ -812,6 +2474,12 @@
             "state": "translated",
             "value": "Disabled by repo"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deshabilitado por el repositorio"
+          }
         }
       }
     },
@@ -822,6 +2490,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Disconnect"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar"
+          }
+        }
+      }
+    },
+    "Dismiss": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar"
           }
         }
       }
@@ -834,6 +2525,12 @@
             "state": "translated",
             "value": "Done"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo"
+          }
         }
       }
     },
@@ -844,6 +2541,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Download"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar"
           }
         }
       }
@@ -856,6 +2559,12 @@
             "state": "translated",
             "value": "Downloads"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargas"
+          }
         }
       }
     },
@@ -866,6 +2575,182 @@
           "stringUnit": {
             "state": "translated",
             "value": "Drag rows to change their order. Hidden rows will not appear on media detail pages. Episodes only appear for series. Stills and Trailers appear in the Modern interface."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrastra las filas para cambiar su orden. Las filas ocultas no aparecerán en las páginas de detalle. Los episodios solo aparecen para series. Las capturas y los tráilers aparecen en la interfaz Moderna."
+          }
+        }
+      }
+    },
+    "Drop Unmatched Search Results": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drop Unmatched Search Results"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar resultados de búsqueda sin coincidencia"
+          }
+        }
+      }
+    },
+    "Earlier versions of Eclipse automatically synced your library and watch progress through iCloud on this device. That sync is now off, and no data was deleted. You can keep it off or explicitly resume syncing.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Earlier versions of Eclipse automatically synced your library and watch progress through iCloud on this device. That sync is now off, and no data was deleted. You can keep it off or explicitly resume syncing."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versiones anteriores de Eclipse sincronizaban automáticamente tu biblioteca y progreso de visualización mediante iCloud en este dispositivo. Esa sincronización ahora está apagada y no se eliminó ningún dato. Puedes dejarla apagada o reanudarla explícitamente."
+          }
+        }
+      }
+    },
+    "Eclipse": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse"
+          }
+        }
+      }
+    },
+    "Eclipse Player": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse Player"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproductor de Eclipse"
+          }
+        }
+      }
+    },
+    "Eclipse could not change the settings-sync direction while a restore, account change, or recovery is still active. Settings sync remains off. Wait for Cloud Sync to become ready, then try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not change the settings-sync direction while a restore, account change, or recovery is still active. Settings sync remains off. Wait for Cloud Sync to become ready, then try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo cambiar la dirección de sincronización de ajustes mientras una restauración, cambio de cuenta o recuperación sigue activa. La sincronización de ajustes permanece apagada. Espera a que la sincronización en la nube esté lista y vuelve a intentarlo."
+          }
+        }
+      }
+    },
+    "Eclipse could not finish recovery and left the recovery point in place. Stop playback or relaunch the app, then try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not finish recovery and left the recovery point in place. Stop playback or relaunch the app, then try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo terminar la recuperación y dejó el punto de recuperación en su lugar. Detén la reproducción o reinicia la app y vuelve a intentarlo."
+          }
+        }
+      }
+    },
+    "Eclipse could not finish the recovery and left the recovery point in place. Try again after relaunching the app.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not finish the recovery and left the recovery point in place. Try again after relaunching the app."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo terminar la recuperación y dejó el punto de recuperación en su lugar. Vuelve a intentarlo después de reiniciar la app."
+          }
+        }
+      }
+    },
+    "Eclipse could not read the installed Nuvio data, so it preserved the original bytes instead of replacing them. Restore a valid backup or explicitly reset Nuvio plugin data before making changes.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not read the installed Nuvio data, so it preserved the original bytes instead of replacing them. Restore a valid backup or explicitly reset Nuvio plugin data before making changes."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo leer los datos instalados de Nuvio, así que conservó los bytes originales en lugar de reemplazarlos. Restaura una copia de seguridad válida o restablece explícitamente los datos del plugin de Nuvio antes de hacer cambios."
+          }
+        }
+      }
+    },
+    "Eclipse could not safely apply that choice. Settings sync is still off. Wait for the current account or sync operation to finish, then try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not safely apply that choice. Settings sync is still off. Wait for the current account or sync operation to finish, then try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo aplicar esa elección de forma segura. La sincronización de ajustes sigue apagada. Espera a que termine la operación actual de cuenta o sincronización y vuelve a intentarlo."
+          }
+        }
+      }
+    },
+    "Eclipse could not save that change. Your notification history and the matching iOS alert were left intact.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not save that change. Your notification history and the matching iOS alert were left intact."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo guardar ese cambio. Tu historial de notificaciones y la alerta de iOS correspondiente quedaron intactos."
           }
         }
       }
@@ -878,6 +2763,29 @@
             "state": "translated",
             "value": "Eclipse is a GPL-licensed media app with substantial original changes by Soupy-dev."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse es una app multimedia con licencia GPL, con cambios originales considerables realizados por Soupy-dev."
+          }
+        }
+      }
+    },
+    "Eclipse is not responsible for changes, loss, restrictions, suspension, or other issues affecting your chosen cloud service. Use Cloud Sync at your own risk. iCloud, Google Drive, OneDrive, Apple, Google, and Microsoft are trademarks of their respective owners and are not affiliated with Eclipse.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse is not responsible for changes, loss, restrictions, suspension, or other issues affecting your chosen cloud service. Use Cloud Sync at your own risk. iCloud, Google Drive, OneDrive, Apple, Google, and Microsoft are trademarks of their respective owners and are not affiliated with Eclipse."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no es responsable de cambios, pérdidas, restricciones, suspensiones u otros problemas que afecten al servicio de nube que elijas. Usa la sincronización en la nube bajo tu propio riesgo. iCloud, Google Drive, OneDrive, Apple, Google y Microsoft son marcas de sus respectivos dueños y no están afiliadas con Eclipse."
+          }
         }
       }
     },
@@ -888,6 +2796,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eclipse is released under the GNU General Public License version 3."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse se distribuye bajo la Licencia Pública General de GNU versión 3."
+          }
+        }
+      }
+    },
+    "Eclipse kept a recovery point from before the interrupted account change. Restoring it replaces this device's media state with that recovery point and resumes sync. The unreadable data stays on this device.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse kept a recovery point from before the interrupted account change. Restoring it replaces this device's media state with that recovery point and resumes sync. The unreadable data stays on this device."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse conservó un punto de recuperación de antes del cambio de cuenta interrumpido. Restaurarlo reemplaza el estado multimedia de este dispositivo con ese punto de recuperación y reanuda la sincronización. Los datos ilegibles permanecen en este dispositivo."
+          }
+        }
+      }
+    },
+    "Eclipse ships with none. Playback needs one you add.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse ships with none. Playback needs one you add."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no incluye ninguna. La reproducción necesita una que agregues tú."
+          }
+        }
+      }
+    },
+    "Eclipse ships without content sources. Add a Service or Stremio addon in Settings › Services, then come back to play this title.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse ships without content sources. Add a Service or Stremio addon in Settings › Services, then come back to play this title."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no incluye fuentes de contenido. Agrega un servicio o addon de Stremio en Ajustes › Servicios y regresa para reproducir este título."
           }
         }
       }
@@ -900,6 +2865,29 @@
             "state": "translated",
             "value": "Eclipse's privacy policy explains what data the app stores locally and how optional third-party services are handled."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La política de privacidad de Eclipse explica qué datos almacena la app localmente y cómo se gestionan los servicios opcionales de terceros."
+          }
+        }
+      }
+    },
+    "Edit Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar ajustes"
+          }
         }
       }
     },
@@ -910,6 +2898,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Empty"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vacío"
+          }
+        }
+      }
+    },
+    "Enable All Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable All Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar todas las fuentes"
+          }
+        }
+      }
+    },
+    "Enable Better Posters": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Better Posters"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar Better Posters"
           }
         }
       }
@@ -922,6 +2950,80 @@
             "state": "translated",
             "value": "Enable Sync"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar sincronización"
+          }
+        }
+      }
+    },
+    "Enable Watch Together": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Watch Together"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar Ver juntos"
+          }
+        }
+      }
+    },
+    "Enable at least one catalog in Settings to populate your home screen.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable at least one catalog in Settings to populate your home screen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa al menos un catálogo en Ajustes para llenar tu pantalla de inicio."
+          }
+        }
+      }
+    },
+    "Enable at least one stream-capable source to set its priority.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable at least one stream-capable source to set its priority."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa al menos una fuente compatible con transmisión para establecer su prioridad."
+          }
+        }
+      }
+    },
+    "Enable or disable content catalogs and use the arrow buttons to reorder them. The order here determines the order on your home screen. Use Customize to override orientation, size, and card info per catalog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable or disable content catalogs and use the arrow buttons to reorder them. The order here determines the order on your home screen. Use Customize to override orientation, size, and card info per catalog."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva los catálogos de contenido y usa los botones de flecha para reordenarlos. El orden aquí determina el orden en tu pantalla de inicio. Usa Personalizar para anular orientación, tamaño e información de tarjeta por catálogo."
+          }
         }
       }
     },
@@ -932,6 +3034,97 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enable/disable content catalogs and drag to reorder them. The order here determines the order on your home screen. Stremio catalog addons may reduce performance or have visual inconsistencies. Trakt catalogs appear after Trakt is connected."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva los catálogos de contenido y arrástralos para reordenarlos. El orden aquí determina el orden en tu pantalla de inicio. Los addons de catálogo de Stremio pueden reducir el rendimiento o tener inconsistencias visuales. Los catálogos de Trakt aparecen después de conectar Trakt."
+          }
+        }
+      }
+    },
+    "Enable/disable content catalogs and drag to reorder them. The order here determines the order on your home screen. Tap the slider icon to customize orientation, size, and card info for a single catalog. Stremio catalog addons may reduce performance or have visual inconsistencies. Trakt catalogs appear after Trakt is connected.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable/disable content catalogs and drag to reorder them. The order here determines the order on your home screen. Tap the slider icon to customize orientation, size, and card info for a single catalog. Stremio catalog addons may reduce performance or have visual inconsistencies. Trakt catalogs appear after Trakt is connected."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva los catálogos de contenido y arrástralos para reordenarlos. El orden aquí determina el orden en tu pantalla de inicio. Toca el ícono deslizador para personalizar orientación, tamaño e información de tarjeta de un solo catálogo. Los addons de catálogo de Stremio pueden reducir el rendimiento o tener inconsistencias visuales. Los catálogos de Trakt aparecen después de conectar Trakt."
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activado"
+          }
+        }
+      }
+    },
+    "English, Hindi, Japanese": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English, Hindi, Japanese"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español, Hindi, Japonés"
+          }
+        }
+      }
+    },
+    "Enter a new name for this collection.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new name for this collection."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa un nuevo nombre para esta colección."
+          }
+        }
+      }
+    },
+    "Enter a user-supplied HTTPS repo.json, plugin-list JSON, or .sky package URL. Eclipse does not include or recommend a repository.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a user-supplied HTTPS repo.json, plugin-list JSON, or .sky package URL. Eclipse does not include or recommend a repository."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa una URL HTTPS de repo.json, un JSON de lista de plugins, o un paquete .sky proporcionado por el usuario. Eclipse no incluye ni recomienda ningún repositorio."
           }
         }
       }
@@ -944,6 +3137,12 @@
             "state": "translated",
             "value": "Enter decimal number"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa un número decimal"
+          }
         }
       }
     },
@@ -954,6 +3153,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enter number"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa un número"
+          }
+        }
+      }
+    },
+    "Enter secure value": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter secure value"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa un valor seguro"
           }
         }
       }
@@ -966,16 +3188,11 @@
             "state": "translated",
             "value": "Enter text"
           }
-        }
-      }
-    },
-    "Enter the direct JSON file URL": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Enter the direct JSON file URL"
+            "value": "Ingresa texto"
           }
         }
       }
@@ -988,6 +3205,63 @@
             "state": "translated",
             "value": "Enter the Stremio addon manifest URL"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa la URL del manifiesto del addon de Stremio"
+          }
+        }
+      }
+    },
+    "Enter the direct JSON file URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter the direct JSON file URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa la URL directa del archivo JSON"
+          }
+        }
+      }
+    },
+    "Enter this code": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter this code"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa este código"
+          }
+        }
+      }
+    },
+    "Episodes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episodes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episodios"
+          }
         }
       }
     },
@@ -998,6 +3272,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        }
+      }
+    },
+    "Exclude All Sources from Auto Mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exclude All Sources from Auto Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir todas las fuentes del modo automático"
           }
         }
       }
@@ -1010,6 +3307,12 @@
             "state": "translated",
             "value": "Export Failed"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportación fallida"
+          }
         }
       }
     },
@@ -1020,6 +3323,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Export Logs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar registros"
           }
         }
       }
@@ -1032,6 +3341,29 @@
             "state": "translated",
             "value": "Export Reader Logs"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar registros del lector"
+          }
+        }
+      }
+    },
+    "Extra Source Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extra Source Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes adicionales de la fuente"
+          }
         }
       }
     },
@@ -1042,6 +3374,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fetching Streams"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obteniendo transmisiones"
+          }
+        }
+      }
+    },
+    "Filler": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filler"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relleno"
           }
         }
       }
@@ -1054,6 +3409,46 @@
             "state": "translated",
             "value": "Filter Settings"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de filtro"
+          }
+        }
+      }
+    },
+    "Filters": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filters"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtros"
+          }
+        }
+      }
+    },
+    "Following": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Following"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siguiendo"
+          }
         }
       }
     },
@@ -1064,6 +3459,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "Global"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global"
+          }
+        }
+      }
+    },
+    "Global follows the Catalogs card info setting. Choose title, year, rating, any combination, or poster only, just for this catalog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global follows the Catalogs card info setting. Choose title, year, rating, any combination, or poster only, just for this catalog."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global sigue el ajuste de información de tarjeta de Catálogos. Elige título, año, calificación, cualquier combinación, o solo carátula, únicamente para este catálogo."
+          }
+        }
+      }
+    },
+    "Global follows the Catalogs orientation. Automatic chooses one orientation per shelf, using posters for anime or missing backdrop artwork.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global follows the Catalogs orientation. Automatic chooses one orientation per shelf, using posters for anime or missing backdrop artwork."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global sigue la orientación de Catálogos. Automático elige una orientación por fila, usando carátulas para anime o cuando falta la imagen de fondo."
+          }
+        }
+      }
+    },
+    "Global follows the Catalogs orientation. Automatic picks poster or landscape per item.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global follows the Catalogs orientation. Automatic picks poster or landscape per item."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global sigue la orientación de Catálogos. Automático elige carátula u horizontal según el elemento."
           }
         }
       }
@@ -1076,6 +3528,63 @@
             "state": "translated",
             "value": "Global follows the Home Layout orientation. Automatic picks poster or landscape per item."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global sigue la orientación del Diseño de Inicio. Automático elige póster u horizontal según el elemento."
+          }
+        }
+      }
+    },
+    "Go Back": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go Back"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regresar"
+          }
+        }
+      }
+    },
+    "Got it": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Got it"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entendido"
+          }
+        }
+      }
+    },
+    "HTTPS repository or .sky URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS repository or .sky URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repositorio HTTPS o URL .sky"
+          }
         }
       }
     },
@@ -1086,6 +3595,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Health check pending"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificación de estado pendiente"
           }
         }
       }
@@ -1098,6 +3613,12 @@
             "state": "translated",
             "value": "Help support the app. Any amount helps keep the app free for everyone"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayuda a apoyar la app. Cualquier cantidad ayuda a mantenerla gratuita para todos"
+          }
         }
       }
     },
@@ -1108,6 +3629,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Help support the app. Any amount helps keep the app free for everyone. Thanks for using the app and supporting development!"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayuda a apoyar la app. Cualquier cantidad ayuda a mantenerla gratuita para todos. ¡Gracias por usar la app y apoyar su desarrollo!"
           }
         }
       }
@@ -1120,6 +3647,12 @@
             "state": "translated",
             "value": "Hero"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destacado"
+          }
         }
       }
     },
@@ -1130,6 +3663,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hide Splash Screen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar pantalla de bienvenida"
+          }
+        }
+      }
+    },
+    "Hide Streams Without Detected Quality": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Streams Without Detected Quality"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar transmisiones sin calidad detectada"
+          }
+        }
+      }
+    },
+    "Hide Streams Without Language Data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Streams Without Language Data"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar transmisiones sin datos de idioma"
           }
         }
       }
@@ -1142,6 +3715,12 @@
             "state": "translated",
             "value": "Higher"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más alto"
+          }
         }
       }
     },
@@ -1152,6 +3731,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Highest"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más alto"
           }
         }
       }
@@ -1164,6 +3749,12 @@
             "state": "translated",
             "value": "Home"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicio"
+          }
         }
       }
     },
@@ -1175,16 +3766,11 @@
             "state": "translated",
             "value": "Home Layout"
           }
-        }
-      }
-    },
-    "iCloud Sync": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "iCloud Sync"
+            "value": "Diseño de inicio"
           }
         }
       }
@@ -1197,6 +3783,12 @@
             "state": "translated",
             "value": "Import"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar"
+          }
         }
       }
     },
@@ -1207,6 +3799,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Import AniList Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar biblioteca de AniList"
           }
         }
       }
@@ -1219,6 +3817,12 @@
             "state": "translated",
             "value": "Import MAL Library"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar biblioteca de MAL"
+          }
         }
       }
     },
@@ -1229,6 +3833,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Import MAL lists as Eclipse collections and reader progress"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa listas de MAL como colecciones de Eclipse y progreso de lectura"
           }
         }
       }
@@ -1241,6 +3851,29 @@
             "state": "translated",
             "value": "Import Trakt Library"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar biblioteca de Trakt"
+          }
+        }
+      }
+    },
+    "Import a backup or connect a cloud provider to pick up where you left off.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import a backup or connect a cloud provider to pick up where you left off."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa una copia de seguridad o conecta un proveedor de nube para continuar donde lo dejaste."
+          }
         }
       }
     },
@@ -1251,6 +3884,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Import your Watching, Planning, and Completed lists as collections"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa tus listas de Viendo, Planeando y Completado como colecciones"
           }
         }
       }
@@ -1263,6 +3902,80 @@
             "state": "translated",
             "value": "Import your watchlist and watched progress as collections"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa tu lista de seguimiento y progreso visto como colecciones"
+          }
+        }
+      }
+    },
+    "Include All Sources in Auto Mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include All Sources in Auto Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluir todas las fuentes en el modo automático"
+          }
+        }
+      }
+    },
+    "Increase": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Increase"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumentar"
+          }
+        }
+      }
+    },
+    "Increase Size": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Increase Size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumentar tamaño"
+          }
+        }
+      }
+    },
+    "Individual Episodes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Individual Episodes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episodios individuales"
+          }
         }
       }
     },
@@ -1273,6 +3986,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Informations Language"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma de la información"
+          }
+        }
+      }
+    },
+    "Install": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar"
+          }
+        }
+      }
+    },
+    "Installed plugins remain available. Their pinned repository will be marked unavailable for updates.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed plugins remain available. Their pinned repository will be marked unavailable for updates."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los plugins instalados siguen disponibles. Su repositorio fijado se marcará como no disponible para actualizaciones."
           }
         }
       }
@@ -1285,6 +4038,12 @@
             "state": "translated",
             "value": "Interface & Scope"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interfaz y alcance"
+          }
         }
       }
     },
@@ -1295,6 +4054,97 @@
           "stringUnit": {
             "state": "translated",
             "value": "JSON URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL de JSON"
+          }
+        }
+      }
+    },
+    "Keep Off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Off"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantener apagado"
+          }
+        }
+      }
+    },
+    "Keep Waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Waiting"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seguir esperando"
+          }
+        }
+      }
+    },
+    "Keep supported preferences such as subtitle appearance, audio language, player behavior, and home layout in sync. Turn this off to give this Apple TV its own settings while your library and progress continue syncing. Installed sources sync separately.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep supported preferences such as subtitle appearance, audio language, player behavior, and home layout in sync. Turn this off to give this Apple TV its own settings while your library and progress continue syncing. Installed sources sync separately."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantiene sincronizadas las preferencias compatibles como apariencia de subtítulos, idioma de audio, comportamiento del reproductor y diseño de inicio. Desactívalo para que este Apple TV tenga sus propios ajustes mientras tu biblioteca y progreso siguen sincronizándose. Las fuentes instaladas se sincronizan por separado."
+          }
+        }
+      }
+    },
+    "Kids profile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kids profile"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perfil infantil"
+          }
+        }
+      }
+    },
+    "Kids profiles hide adult, horror, and other mature titles across home, search, and catalogs.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kids profiles hide adult, horror, and other mature titles across home, search, and catalogs."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los perfiles infantiles ocultan títulos para adultos, de terror y otro contenido maduro en inicio, búsqueda y catálogos."
           }
         }
       }
@@ -1307,6 +4157,46 @@
             "state": "translated",
             "value": "Language"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma"
+          }
+        }
+      }
+    },
+    "Languages to Exclude": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Languages to Exclude"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas a excluir"
+          }
+        }
+      }
+    },
+    "Languages to Include": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Languages to Include"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas a incluir"
+          }
         }
       }
     },
@@ -1317,6 +4207,80 @@
           "stringUnit": {
             "state": "translated",
             "value": "Large sync: Eclipse will show progress, honor rate limits, and keep this sheet open until it finishes or you cancel."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización grande: Eclipse mostrará el progreso, respetará los límites de solicitudes y mantendrá esta ventana abierta hasta que termine o la canceles."
+          }
+        }
+      }
+    },
+    "Later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Later"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más tarde"
+          }
+        }
+      }
+    },
+    "Layout & Details": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout & Details"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diseño y detalles"
+          }
+        }
+      }
+    },
+    "Leave Session": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leave Session"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir de la sesión"
+          }
+        }
+      }
+    },
+    "Leave Watch Together?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leave Watch Together?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Salir de Ver juntos?"
           }
         }
       }
@@ -1329,6 +4293,12 @@
             "state": "translated",
             "value": "Legal & Source"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legal y código fuente"
+          }
         }
       }
     },
@@ -1339,6 +4309,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biblioteca"
           }
         }
       }
@@ -1351,6 +4327,12 @@
             "state": "translated",
             "value": "Live Trakt Scrobbling"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scrobbling en vivo de Trakt"
+          }
         }
       }
     },
@@ -1361,6 +4343,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Loading amazing content..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando contenido increíble..."
           }
         }
       }
@@ -1373,6 +4361,29 @@
             "state": "translated",
             "value": "Loading episodes..."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando episodios..."
+          }
+        }
+      }
+    },
+    "Loading notification history…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading notification history…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando historial de notificaciones…"
+          }
         }
       }
     },
@@ -1383,6 +4394,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Loading settings..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando ajustes..."
           }
         }
       }
@@ -1395,6 +4412,12 @@
             "state": "translated",
             "value": "Loading..."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando..."
+          }
         }
       }
     },
@@ -1405,6 +4428,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Local"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local"
+          }
+        }
+      }
+    },
+    "Log In": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Log In"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar sesión"
           }
         }
       }
@@ -1417,6 +4463,12 @@
             "state": "translated",
             "value": "Logger"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registro"
+          }
         }
       }
     },
@@ -1427,6 +4479,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lower"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más bajo"
           }
         }
       }
@@ -1439,6 +4497,63 @@
             "state": "translated",
             "value": "Lowest"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más bajo"
+          }
+        }
+      }
+    },
+    "MAL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAL"
+          }
+        }
+      }
+    },
+    "Manage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administrar"
+          }
+        }
+      }
+    },
+    "Manifest URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manifest URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del manifiesto"
+          }
         }
       }
     },
@@ -1450,38 +4565,11 @@
             "state": "translated",
             "value": "Manual Select"
           }
-        }
-      }
-    },
-    "Mark as Not Watched": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mark as Not Watched"
-          }
-        }
-      }
-    },
-    "Mark as Unwatched": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mark as Unwatched"
-          }
-        }
-      }
-    },
-    "Mark as Watched": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mark as Watched"
+            "value": "Selección manual"
           }
         }
       }
@@ -1494,6 +4582,12 @@
             "state": "translated",
             "value": "Mark Previous as Not Watched"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar anteriores como no vistos"
+          }
         }
       }
     },
@@ -1504,6 +4598,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mark Previous as Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar anteriores como vistos"
+          }
+        }
+      }
+    },
+    "Mark as Not Watched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark as Not Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar como no visto"
+          }
+        }
+      }
+    },
+    "Mark as Unwatched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark as Unwatched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar como no visto"
+          }
+        }
+      }
+    },
+    "Mark as Watched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark as Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar como visto"
           }
         }
       }
@@ -1516,6 +4667,12 @@
             "state": "translated",
             "value": "Matching Algorithm"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algoritmo de coincidencia"
+          }
         }
       }
     },
@@ -1526,6 +4683,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Media Detail Page"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página de detalle multimedia"
           }
         }
       }
@@ -1538,6 +4701,29 @@
             "state": "translated",
             "value": "Media Player"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproductor multimedia"
+          }
+        }
+      }
+    },
+    "Media state stays on this Apple TV until you turn sync on.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Media state stays on this Apple TV until you turn sync on."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estado multimedia permanece en este Apple TV hasta que actives la sincronización."
+          }
         }
       }
     },
@@ -1548,6 +4734,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Medium"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medio"
           }
         }
       }
@@ -1560,6 +4752,12 @@
             "state": "translated",
             "value": "Message"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensaje"
+          }
         }
       }
     },
@@ -1570,6 +4768,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moderno"
+          }
+        }
+      }
+    },
+    "Move Down": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move Down"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover abajo"
+          }
+        }
+      }
+    },
+    "Move Up": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move Up"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover arriba"
           }
         }
       }
@@ -1582,6 +4820,29 @@
             "state": "translated",
             "value": "Movies"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Películas"
+          }
+        }
+      }
+    },
+    "Movies & TV Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Movies & TV Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Películas y series"
+          }
         }
       }
     },
@@ -1592,6 +4853,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Multi Gradient"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Multidegradado"
+          }
+        }
+      }
+    },
+    "Name it now, or skip and keep the default.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name it now, or skip and keep the default."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponle nombre ahora, o omite y conserva el predeterminado."
+          }
+        }
+      }
+    },
+    "Names and trademarks belong to their respective owners. These acknowledgements do not imply affiliation or endorsement. Each project and service remains subject to its linked license or terms. Eclipse's corresponding source is available from the License & Source page.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Names and trademarks belong to their respective owners. These acknowledgements do not imply affiliation or endorsement. Each project and service remains subject to its linked license or terms. Eclipse's corresponding source is available from the License & Source page."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los nombres y marcas pertenecen a sus respectivos dueños. Estos reconocimientos no implican afiliación ni aprobación. Cada proyecto y servicio sigue sujeto a su licencia o términos correspondientes. El código fuente de Eclipse está disponible en la página de Licencia y código fuente."
           }
         }
       }
@@ -1604,6 +4905,12 @@
             "state": "translated",
             "value": "Network"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red"
+          }
         }
       }
     },
@@ -1614,6 +4921,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "New Addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva URL de addon"
           }
         }
       }
@@ -1626,6 +4939,12 @@
             "state": "translated",
             "value": "New Collection"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva colección"
+          }
         }
       }
     },
@@ -1636,6 +4955,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No Active Services"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin servicios activos"
           }
         }
       }
@@ -1648,60 +4973,62 @@
             "state": "translated",
             "value": "No Active Sources"
           }
-        }
-      }
-    },
-    "No episodes scheduled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No episodes scheduled"
+            "value": "Sin fuentes activas"
           }
         }
       }
     },
-    "No items in this collection": {
+    "No Catalogs Enabled": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No items in this collection"
+            "value": "No Catalogs Enabled"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay catálogos activados"
           }
         }
       }
     },
-    "No plugin providers installed": {
+    "No Repositories": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No plugin providers installed"
+            "value": "No Repositories"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin repositorios"
           }
         }
       }
     },
-    "No plugin repositories installed": {
+    "No Results": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No plugin repositories installed"
+            "value": "No Results"
           }
-        }
-      }
-    },
-    "No results found": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No results found"
+            "value": "Sin resultados"
           }
         }
       }
@@ -1714,16 +5041,11 @@
             "state": "translated",
             "value": "No Services"
           }
-        }
-      }
-    },
-    "No services or addons installed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No services or addons installed"
+            "value": "Sin servicios"
           }
         }
       }
@@ -1736,6 +5058,46 @@
             "state": "translated",
             "value": "No Settings Available"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay ajustes disponibles"
+          }
+        }
+      }
+    },
+    "No Settings Found": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Settings Found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron ajustes"
+          }
+        }
+      }
+    },
+    "No Sources Installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Sources Installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay fuentes instaladas"
+          }
         }
       }
     },
@@ -1746,6 +5108,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No Subtitles"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin subtítulos"
           }
         }
       }
@@ -1758,6 +5126,216 @@
             "state": "translated",
             "value": "No TMDB Entry"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin entrada de TMDB"
+          }
+        }
+      }
+    },
+    "No aired episodes yet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No aired episodes yet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay episodios emitidos"
+          }
+        }
+      }
+    },
+    "No connected stream sources.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No connected stream sources."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay fuentes de transmisión conectadas."
+          }
+        }
+      }
+    },
+    "No episodes found.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No episodes found."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron episodios."
+          }
+        }
+      }
+    },
+    "No episodes scheduled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No episodes scheduled"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay episodios programados"
+          }
+        }
+      }
+    },
+    "No items in this collection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No items in this collection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay elementos en esta colección"
+          }
+        }
+      }
+    },
+    "No plugin providers installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No plugin providers installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay proveedores de plugins instalados"
+          }
+        }
+      }
+    },
+    "No plugin repositories installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No plugin repositories installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay repositorios de plugins instalados"
+          }
+        }
+      }
+    },
+    "No providers are ready yet. Retry the failed downloads above.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No providers are ready yet. Retry the failed downloads above."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todavía no hay proveedores listos. Reintenta las descargas fallidas de arriba."
+          }
+        }
+      }
+    },
+    "No results found": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No results found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron resultados"
+          }
+        }
+      }
+    },
+    "No services or addons installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No services or addons installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay servicios ni addons instalados"
+          }
+        }
+      }
+    },
+    "No stream sources installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No stream sources installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay fuentes de transmisión instaladas"
+          }
+        }
+      }
+    },
+    "No streams match your current filters. Go back to Source Results to change them.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No streams match your current filters. Go back to Source Results to change them."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna transmisión coincide con tus filtros actuales. Regresa a Resultados de fuente para cambiarlos."
+          }
         }
       }
     },
@@ -1768,6 +5346,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "None"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguno"
           }
         }
       }
@@ -1780,6 +5364,46 @@
             "state": "translated",
             "value": "Normal"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal"
+          }
+        }
+      }
+    },
+    "Not Now": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Now"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ahora no"
+          }
+        }
+      }
+    },
+    "Not available on this profile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not available on this profile"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No disponible en este perfil"
+          }
         }
       }
     },
@@ -1791,16 +5415,79 @@
             "state": "translated",
             "value": "Not searched"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No buscado"
+          }
         }
       }
     },
-    "Off follows the global size. Widget rows support size only.": {
+    "Notification Center": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Off follows the global size. Widget rows support size only."
+            "value": "Notification Center"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro de notificaciones"
+          }
+        }
+      }
+    },
+    "Notifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificaciones"
+          }
+        }
+      }
+    },
+    "Now Playing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Now Playing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduciendo ahora"
+          }
+        }
+      }
+    },
+    "Nuvio Plugins": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuvio Plugins"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plugins de Nuvio"
           }
         }
       }
@@ -1813,6 +5500,97 @@
             "state": "translated",
             "value": "OK"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
+          }
+        }
+      }
+    },
+    "Off follows the global size. Widget rows support size only.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off follows the global size. Widget rows support size only."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivado sigue el tamaño global. Las filas de widgets solo admiten tamaño."
+          }
+        }
+      }
+    },
+    "On your phone or computer, visit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On your phone or computer, visit"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En tu teléfono o computadora, visita"
+          }
+        }
+      }
+    },
+    "Open Release": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Release"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir lanzamiento"
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir ajustes"
+          }
+        }
+      }
+    },
+    "Open on Nearby Device": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open on Nearby Device"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir en dispositivo cercano"
+          }
         }
       }
     },
@@ -1823,6 +5601,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Optional"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcional"
           }
         }
       }
@@ -1835,6 +5619,46 @@
             "state": "translated",
             "value": "Orientation"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientación"
+          }
+        }
+      }
+    },
+    "Orientation, card size and card info (title, year, rating) moved to Settings > Catalogs, where they can also be customized per catalog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientation, card size and card info (title, year, rating) moved to Settings > Catalogs, where they can also be customized per catalog."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientación, tamaño de tarjeta e información de tarjeta (título, año, calificación) se movieron a Ajustes > Catálogos, donde también se pueden personalizar por catálogo."
+          }
+        }
+      }
+    },
+    "Orientation, size, and card info (title, year, rating) apply to every catalog on the home screen by default. Use the slider icon on a catalog below to override any of these just for that catalog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientation, size, and card info (title, year, rating) apply to every catalog on the home screen by default. Use the slider icon on a catalog below to override any of these just for that catalog."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientación, tamaño e información de tarjeta (título, año, calificación) se aplican a todos los catálogos de la pantalla de inicio por defecto. Usa el ícono deslizador de un catálogo abajo para anular cualquiera de estos solo para ese catálogo."
+          }
         }
       }
     },
@@ -1845,6 +5669,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Others"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otros"
           }
         }
       }
@@ -1857,6 +5687,12 @@
             "state": "translated",
             "value": "Palette"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paleta"
+          }
         }
       }
     },
@@ -1867,6 +5703,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Paste the new configured addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pega la nueva URL del addon configurado"
           }
         }
       }
@@ -1879,6 +5721,12 @@
             "state": "translated",
             "value": "Pause"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar"
+          }
         }
       }
     },
@@ -1889,6 +5737,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pause All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar todo"
           }
         }
       }
@@ -1901,6 +5755,12 @@
             "state": "translated",
             "value": "Per Catalog"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por catálogo"
+          }
         }
       }
     },
@@ -1911,6 +5771,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Performance Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de rendimiento"
           }
         }
       }
@@ -1923,6 +5789,29 @@
             "state": "translated",
             "value": "Play"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducir"
+          }
+        }
+      }
+    },
+    "Player Skin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Player Skin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apariencia del reproductor"
+          }
         }
       }
     },
@@ -1933,6 +5822,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "Plugins"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plugins"
+          }
+        }
+      }
+    },
+    "Poster Artwork": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poster Artwork"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imagen de carátula"
+          }
+        }
+      }
+    },
+    "Poster URL Pattern": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poster URL Pattern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Patrón de URL de carátula"
+          }
+        }
+      }
+    },
+    "Preferences": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferences"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferencias"
           }
         }
       }
@@ -1945,6 +5891,12 @@
             "state": "translated",
             "value": "Preview"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista previa"
+          }
         }
       }
     },
@@ -1955,6 +5907,148 @@
           "stringUnit": {
             "state": "translated",
             "value": "Preview imports, pushes, and AniList/MAL ports"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista previa de importaciones, envíos y migraciones de AniList/MAL"
+          }
+        }
+      }
+    },
+    "Prices load from the App Store when these purchases become available.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prices load from the App Store when these purchases become available."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los precios se cargan desde la App Store cuando estas compras estén disponibles."
+          }
+        }
+      }
+    },
+    "Privacy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacidad"
+          }
+        }
+      }
+    },
+    "Private notes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private notes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notas privadas"
+          }
+        }
+      }
+    },
+    "Profile name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del perfil"
+          }
+        }
+      }
+    },
+    "Provider URLs, authorization tokens, cookies, and request headers are intentionally omitted.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provider URLs, authorization tokens, cookies, and request headers are intentionally omitted."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las URLs de proveedor, tokens de autorización, cookies y encabezados de solicitud se omiten intencionalmente."
+          }
+        }
+      }
+    },
+    "Providers from installed repositories appear in Services alongside your other sources.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Providers from installed repositories appear in Services alongside your other sources."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los proveedores de repositorios instalados aparecen en Servicios junto a tus otras fuentes."
+          }
+        }
+      }
+    },
+    "Purchases use the App Store on this Apple TV. External donation and community links are not shown in the TV app.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Purchases use the App Store on this Apple TV. External donation and community links are not shown in the TV app."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las compras usan la App Store en este Apple TV. Los enlaces externos de donación y comunidad no se muestran en la app de TV."
+          }
+        }
+      }
+    },
+    "Qualities to Hide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualities to Hide"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calidades a ocultar"
           }
         }
       }
@@ -1967,6 +6061,12 @@
             "state": "translated",
             "value": "Quality"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calidad"
+          }
         }
       }
     },
@@ -1977,6 +6077,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Quality Threshold"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbral de calidad"
+          }
+        }
+      }
+    },
+    "Random": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Random"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aleatorio"
+          }
+        }
+      }
+    },
+    "Ranking Similarity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ranking Similarity"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Similitud de clasificación"
           }
         }
       }
@@ -1989,6 +6129,12 @@
             "state": "translated",
             "value": "Rating & Notes"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calificación y notas"
+          }
         }
       }
     },
@@ -1999,6 +6145,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reachable"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcanzable"
           }
         }
       }
@@ -2011,6 +6163,29 @@
             "state": "translated",
             "value": "Reader Logs"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registros del lector"
+          }
+        }
+      }
+    },
+    "Reading provider settings…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reading provider settings…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leyendo ajustes del proveedor…"
+          }
         }
       }
     },
@@ -2021,6 +6196,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Recalculate cache size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recalcular tamaño de caché"
           }
         }
       }
@@ -2033,6 +6214,12 @@
             "state": "translated",
             "value": "Recent Searches"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Búsquedas recientes"
+          }
         }
       }
     },
@@ -2043,6 +6230,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reconfigure Addon"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconfigurar addon"
           }
         }
       }
@@ -2055,6 +6248,97 @@
             "state": "translated",
             "value": "Reconfigure Error"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al reconfigurar"
+          }
+        }
+      }
+    },
+    "Recovery Not Completed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recovery Not Completed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuperación no completada"
+          }
+        }
+      }
+    },
+    "Refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
+          }
+        }
+      }
+    },
+    "Refresh Repository": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh Repository"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar repositorio"
+          }
+        }
+      }
+    },
+    "Refresh Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar fuentes"
+          }
+        }
+      }
+    },
+    "Rejoin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rejoin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a unirse"
+          }
         }
       }
     },
@@ -2065,6 +6349,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Remove"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar"
+          }
+        }
+      }
+    },
+    "Remove All": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar todo"
+          }
+        }
+      }
+    },
+    "Remove All Notification Selections": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove All Notification Selections"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar todas las selecciones de notificación"
           }
         }
       }
@@ -2077,6 +6401,199 @@
             "state": "translated",
             "value": "Remove Download"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar descarga"
+          }
+        }
+      }
+    },
+    "Remove Repository": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Repository"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar repositorio"
+          }
+        }
+      }
+    },
+    "Remove Repository?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Repository?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Quitar repositorio?"
+          }
+        }
+      }
+    },
+    "Remove Service?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Service?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Quitar servicio?"
+          }
+        }
+      }
+    },
+    "Remove Stremio Addon?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Stremio Addon?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Quitar addon de Stremio?"
+          }
+        }
+      }
+    },
+    "Removing a repository keeps installed plugins and their settings, but freezes their update provenance.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removing a repository keeps installed plugins and their settings, but freezes their update provenance."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar un repositorio conserva los plugins instalados y sus ajustes, pero congela su procedencia de actualización."
+          }
+        }
+      }
+    },
+    "Rename": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar"
+          }
+        }
+      }
+    },
+    "Rename Collection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Collection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar colección"
+          }
+        }
+      }
+    },
+    "Replace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replace"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reemplazar"
+          }
+        }
+      }
+    },
+    "Replace Cloud Backup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replace Cloud Backup"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reemplazar copia de seguridad en la nube"
+          }
+        }
+      }
+    },
+    "Replace Everywhere": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replace Everywhere"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reemplazar en todos lados"
+          }
+        }
+      }
+    },
+    "Replace poster artwork with images from Better Posters (btttr.cc), a community poster service.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replace poster artwork with images from Better Posters (btttr.cc), a community poster service."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reemplaza la imagen de las carátulas con imágenes de Better Posters (btttr.cc), un servicio comunitario de carátulas."
+          }
         }
       }
     },
@@ -2087,6 +6604,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Repository URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del repositorio"
+          }
+        }
+      }
+    },
+    "Repository unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repository unavailable"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repositorio no disponible"
           }
         }
       }
@@ -2099,6 +6639,46 @@
             "state": "translated",
             "value": "Requires MoltenVK MPV"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requiere MoltenVK MPV"
+          }
+        }
+      }
+    },
+    "Requires SharePlay. Eclipse can start an invitation, or join an existing FaceTime or Messages group. Participants need access to the same title in Eclipse.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requires SharePlay. Eclipse can start an invitation, or join an existing FaceTime or Messages group. Participants need access to the same title in Eclipse."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requiere SharePlay. Eclipse puede iniciar una invitación, o unirse a un grupo existente de FaceTime o Mensajes. Los participantes necesitan acceso al mismo título en Eclipse."
+          }
+        }
+      }
+    },
+    "Reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer"
+          }
         }
       }
     },
@@ -2109,6 +6689,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reset All Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer todos los catálogos"
           }
         }
       }
@@ -2121,6 +6707,12 @@
             "state": "translated",
             "value": "Reset Appearance"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer apariencia"
+          }
         }
       }
     },
@@ -2131,6 +6723,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reset Media Detail Layout"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer diseño de detalle multimedia"
+          }
+        }
+      }
+    },
+    "Reset Nuvio Plugin Data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Nuvio Plugin Data"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer datos del plugin de Nuvio"
+          }
+        }
+      }
+    },
+    "Reset Plugin Preferences": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Plugin Preferences"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer preferencias del plugin"
+          }
+        }
+      }
+    },
+    "Reset Preferences?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Preferences?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Restablecer preferencias?"
           }
         }
       }
@@ -2143,6 +6792,80 @@
             "state": "translated",
             "value": "Reset Progress"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer progreso"
+          }
+        }
+      }
+    },
+    "Reset SkyStream Data?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset SkyStream Data?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Restablecer datos de SkyStream?"
+          }
+        }
+      }
+    },
+    "Reset SkyStream Plugin Data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset SkyStream Plugin Data"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer datos del plugin de SkyStream"
+          }
+        }
+      }
+    },
+    "Reset TV Cache": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset TV Cache"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer caché de TV"
+          }
+        }
+      }
+    },
+    "Reset TV Cache?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset TV Cache?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Restablecer caché de TV?"
+          }
         }
       }
     },
@@ -2153,6 +6876,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reset to Global"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer a global"
           }
         }
       }
@@ -2165,6 +6894,12 @@
             "state": "translated",
             "value": "Resets theme, layout and per-catalog overrides to their defaults."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablece el tema, el diseño y las anulaciones por catálogo a sus valores predeterminados."
+          }
         }
       }
     },
@@ -2175,6 +6910,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Resets theme, layout, app experience, and per-catalog overrides to their defaults."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablece el tema, el diseño, la experiencia de la app y las anulaciones por catálogo a sus valores predeterminados."
+          }
+        }
+      }
+    },
+    "Resetting clears the saved repositories and installed packages on this device so SkyStream can start over.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetting clears the saved repositories and installed packages on this device so SkyStream can start over."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer borra los repositorios guardados y los paquetes instalados en este dispositivo para que SkyStream empiece de nuevo."
+          }
+        }
+      }
+    },
+    "Restart Eclipse to finish switching the interface language.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart Eclipse to finish switching the interface language."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reinicia Eclipse para terminar de cambiar el idioma de la interfaz."
           }
         }
       }
@@ -2187,6 +6962,12 @@
             "state": "translated",
             "value": "Restart Required"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requiere reiniciar"
+          }
         }
       }
     },
@@ -2197,6 +6978,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restart required to apply the interface change"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requiere reiniciar para aplicar el cambio de interfaz"
           }
         }
       }
@@ -2209,6 +6996,12 @@
             "state": "translated",
             "value": "Restore"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar"
+          }
         }
       }
     },
@@ -2219,6 +7012,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restore Confirmation"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar restauración"
+          }
+        }
+      }
+    },
+    "Restore From Recovery Point": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore From Recovery Point"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar desde el punto de recuperación"
+          }
+        }
+      }
+    },
+    "Restore and Resume Sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore and Resume Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar y reanudar sincronización"
           }
         }
       }
@@ -2231,6 +7064,12 @@
             "state": "translated",
             "value": "Restore the default order and visibility."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaura el orden y la visibilidad predeterminados."
+          }
         }
       }
     },
@@ -2241,6 +7080,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restore the default theme and layout values."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaura los valores predeterminados de tema y diseño."
           }
         }
       }
@@ -2253,6 +7098,29 @@
             "state": "translated",
             "value": "Restore the default theme, layout, animation, and startup display values."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaura los valores predeterminados de tema, diseño, animación y pantalla de inicio."
+          }
+        }
+      }
+    },
+    "Results at or above this percentage are prioritized by similarity. When dropping is enabled, search results below this percentage are hidden, Auto Mode skips them instead of using a weaker match, and plugin sources tighten to the same percentage. Percentages under 85% apply to Service sources only, because plugin sources never accept a match below 85%.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Results at or above this percentage are prioritized by similarity. When dropping is enabled, search results below this percentage are hidden, Auto Mode skips them instead of using a weaker match, and plugin sources tighten to the same percentage. Percentages under 85% apply to Service sources only, because plugin sources never accept a match below 85%."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los resultados en o por encima de este porcentaje se priorizan por similitud. Cuando el descarte está activado, los resultados de búsqueda por debajo de este porcentaje se ocultan, el modo automático los omite en lugar de usar una coincidencia más débil, y las fuentes de plugins se ajustan al mismo porcentaje. Los porcentajes menores al 85% aplican solo a fuentes de servicio, porque las fuentes de plugins nunca aceptan una coincidencia menor al 85%."
+          }
         }
       }
     },
@@ -2263,6 +7131,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Resume"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar"
           }
         }
       }
@@ -2275,6 +7149,29 @@
             "state": "translated",
             "value": "Resume All"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar todo"
+          }
+        }
+      }
+    },
+    "Resume Sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar sincronización"
+          }
         }
       }
     },
@@ -2285,6 +7182,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Retry"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintentar"
           }
         }
       }
@@ -2297,6 +7200,12 @@
             "state": "translated",
             "value": "Retry Failed"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintento fallido"
+          }
         }
       }
     },
@@ -2307,6 +7216,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Review"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reseña"
           }
         }
       }
@@ -2319,6 +7234,12 @@
             "state": "translated",
             "value": "Rows set to Global follow the settings above. Orientation applies to standard poster rows; widget rows support size only."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las filas configuradas como Global siguen los ajustes anteriores. La orientación aplica a las filas de pósters estándar; las filas de widgets solo admiten tamaño."
+          }
         }
       }
     },
@@ -2329,6 +7250,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Run"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar"
           }
         }
       }
@@ -2341,6 +7268,12 @@
             "state": "translated",
             "value": "Run Sync Tool?"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Ejecutar herramienta de sincronización?"
+          }
         }
       }
     },
@@ -2351,6 +7284,97 @@
           "stringUnit": {
             "state": "translated",
             "value": "Save"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
+          }
+        }
+      }
+    },
+    "Save Configured URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Configured URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar URL configurado"
+          }
+        }
+      }
+    },
+    "Save Excluded Languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Excluded Languages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar idiomas excluidos"
+          }
+        }
+      }
+    },
+    "Save Included Languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Included Languages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar idiomas incluidos"
+          }
+        }
+      }
+    },
+    "Save to Photos": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save to Photos"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar en Fotos"
+          }
+        }
+      }
+    },
+    "Scan QR": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan QR"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escanear QR"
           }
         }
       }
@@ -2363,6 +7387,12 @@
             "state": "translated",
             "value": "Schedule"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calendario"
+          }
         }
       }
     },
@@ -2373,6 +7403,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Search"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
           }
         }
       }
@@ -2385,6 +7421,12 @@
             "state": "translated",
             "value": "Search Movies & TV Shows"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar películas y series"
+          }
         }
       }
     },
@@ -2395,6 +7437,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Search..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcador de posición de búsqueda"
+          }
+        }
+      }
+    },
+    "Search Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar en ajustes"
           }
         }
       }
@@ -2407,6 +7472,12 @@
             "state": "translated",
             "value": "Searching for:"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando:"
+          }
         }
       }
     },
@@ -2417,6 +7488,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Searching..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando..."
           }
         }
       }
@@ -2429,6 +7506,114 @@
             "state": "translated",
             "value": "Seasons"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temporadas"
+          }
+        }
+      }
+    },
+    "Secure, synchronized playback through Apple SharePlay.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secure, synchronized playback through Apple SharePlay."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducción segura y sincronizada mediante Apple SharePlay."
+          }
+        }
+      }
+    },
+    "Security Check": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Security Check"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificación de seguridad"
+          }
+        }
+      }
+    },
+    "See All": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver todo"
+          }
+        }
+      }
+    },
+    "See what's airing next": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See what's airing next"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mira qué se transmite después"
+          }
+        }
+      }
+    },
+    "Select Stream": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Stream"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar transmisión"
+          }
+        }
+      }
+    },
+    "Selection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selección"
+          }
         }
       }
     },
@@ -2439,6 +7624,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Services"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servicios"
           }
         }
       }
@@ -2451,6 +7642,12 @@
             "state": "translated",
             "value": "Services & Addons"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servicios y addons"
+          }
         }
       }
     },
@@ -2461,6 +7658,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
           }
         }
       }
@@ -2473,6 +7676,63 @@
             "state": "translated",
             "value": "Settings Saved"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes guardados"
+          }
+        }
+      }
+    },
+    "Settings Sync Is Paused": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings Sync Is Paused"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sincronización de ajustes está en pausa"
+          }
+        }
+      }
+    },
+    "Settings and Reader Mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings and Reader Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes y modo lector"
+          }
+        }
+      }
+    },
+    "Settings moved somewhere easier to reach. Tap the handle on the edge of the screen.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings moved somewhere easier to reach. Tap the handle on the edge of the screen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los ajustes se movieron a un lugar más fácil de alcanzar. Toca el asa en el borde de la pantalla."
+          }
         }
       }
     },
@@ -2484,16 +7744,62 @@
             "state": "translated",
             "value": "Share"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir"
+          }
         }
       }
     },
-    "Shows": {
+    "SharePlay": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Shows"
+            "value": "SharePlay"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SharePlay"
+          }
+        }
+      }
+    },
+    "SharePlay displays the title; sync messages contain only play, pause, seek, and an opaque media identifier.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SharePlay displays the title; sync messages contain only play, pause, seek, and an opaque media identifier."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SharePlay muestra el título; los mensajes de sincronización solo contienen reproducir, pausar, buscar y un identificador de medio opaco."
+          }
+        }
+      }
+    },
+    "SharePlay messages are limited to people in the Apple group session.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SharePlay messages are limited to people in the Apple group session."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los mensajes de SharePlay se limitan a las personas en la sesión de grupo de Apple."
           }
         }
       }
@@ -2506,6 +7812,46 @@
             "state": "translated",
             "value": "Show ambient motion behind the home screen."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra movimiento ambiental detrás de la pantalla de inicio."
+          }
+        }
+      }
+    },
+    "Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Series"
+          }
+        }
+      }
+    },
+    "Shows one compact, filterable list of results and streams instead of grouping them into separate source sections.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows one compact, filterable list of results and streams instead of grouping them into separate source sections."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra una lista compacta y filtrable de resultados y transmisiones en lugar de agruparlos en secciones separadas por fuente."
+          }
         }
       }
     },
@@ -2516,6 +7862,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño"
           }
         }
       }
@@ -2528,6 +7880,12 @@
             "state": "translated",
             "value": "Size and orientation of home rows - globally or per catalog."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño y orientación de las filas de inicio, de forma global o por catálogo."
+          }
         }
       }
     },
@@ -2538,6 +7896,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Skip"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitir"
           }
         }
       }
@@ -2550,6 +7914,12 @@
             "state": "translated",
             "value": "Skip Episode"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitir episodio"
+          }
         }
       }
     },
@@ -2560,6 +7930,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Skip the launch splash once Eclipse opens."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omite la pantalla de bienvenida al abrir Eclipse."
+          }
+        }
+      }
+    },
+    "SkyStream Error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SkyStream Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de SkyStream"
+          }
+        }
+      }
+    },
+    "SkyStream Plugins": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SkyStream Plugins"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plugins de SkyStream"
           }
         }
       }
@@ -2572,6 +7982,12 @@
             "state": "translated",
             "value": "Solid Color"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color sólido"
+          }
         }
       }
     },
@@ -2582,6 +7998,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sort"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordenar"
+          }
+        }
+      }
+    },
+    "Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuentes"
           }
         }
       }
@@ -2594,6 +8033,12 @@
             "state": "translated",
             "value": "Specials & OVAs"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Especiales y OVAs"
+          }
         }
       }
     },
@@ -2604,6 +8049,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Stay here while this large sync runs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permanece aquí mientras se ejecuta esta sincronización grande"
           }
         }
       }
@@ -2616,6 +8067,12 @@
             "state": "translated",
             "value": "Storage"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento"
+          }
         }
       }
     },
@@ -2626,6 +8083,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Stream Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de transmisión"
+          }
+        }
+      }
+    },
+    "Stream URLs, request headers, cookies, subtitles, and provider credentials never leave your device.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stream URLs, request headers, cookies, subtitles, and provider credentials never leave your device."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las URLs de transmisión, encabezados de solicitud, cookies, subtítulos y credenciales del proveedor nunca salen de tu dispositivo."
+          }
+        }
+      }
+    },
+    "Stremio Addons": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stremio Addons"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Addons de Stremio"
           }
         }
       }
@@ -2638,6 +8135,29 @@
             "state": "translated",
             "value": "Stremio Error"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de Stremio"
+          }
+        }
+      }
+    },
+    "Stremio-Style Stream List": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stremio-Style Stream List"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lista de transmisiones estilo Stremio"
+          }
         }
       }
     },
@@ -2649,16 +8169,11 @@
             "state": "translated",
             "value": "Support"
           }
-        }
-      }
-    },
-    "Switch to Reader Mode": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Switch to Reader Mode"
+            "value": "Soporte"
           }
         }
       }
@@ -2671,6 +8186,63 @@
             "state": "translated",
             "value": "Switch Mode Animation"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animación al cambiar de modo"
+          }
+        }
+      }
+    },
+    "Switch to Reader Mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch to Reader Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar a modo Lector"
+          }
+        }
+      }
+    },
+    "Sync Health": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Health"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado de la sincronización"
+          }
+        }
+      }
+    },
+    "Sync Settings Across Devices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Settings Across Devices"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizar ajustes entre dispositivos"
+          }
         }
       }
     },
@@ -2681,6 +8253,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sync Tools"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramientas de sincronización"
+          }
+        }
+      }
+    },
+    "Sync with iCloud": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync with iCloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizar con iCloud"
+          }
+        }
+      }
+    },
+    "Tap the handle on the edge of the screen.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap the handle on the edge of the screen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca el asa en el borde de la pantalla."
           }
         }
       }
@@ -2693,6 +8305,12 @@
             "state": "translated",
             "value": "The interface style is applied when Eclipse launches. Restart the app to switch between the Modern and Classic layouts."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estilo de interfaz se aplica cuando Eclipse se inicia. Reinicia la app para cambiar entre los diseños Moderno y Clásico."
+          }
         }
       }
     },
@@ -2703,6 +8321,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "The service settings have been updated successfully."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los ajustes del servicio se actualizaron correctamente."
           }
         }
       }
@@ -2715,6 +8339,12 @@
             "state": "translated",
             "value": "Theme"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema"
+          }
         }
       }
     },
@@ -2725,6 +8355,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "These apply to every home row. Override individual rows below."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estos se aplican a todas las filas de inicio. Anúlalos individualmente por fila más abajo."
           }
         }
       }
@@ -2737,6 +8373,12 @@
             "state": "translated",
             "value": "Thick"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grueso"
+          }
         }
       }
     },
@@ -2747,6 +8389,80 @@
           "stringUnit": {
             "state": "translated",
             "value": "Thin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delgado"
+          }
+        }
+      }
+    },
+    "This Device Only": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Device Only"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo este dispositivo"
+          }
+        }
+      }
+    },
+    "This changes the package's pinned source, installs an older version, or replaces code without a version change. Existing code stays installed unless the replacement fully validates.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This changes the package's pinned source, installs an older version, or replaces code without a version change. Existing code stays installed unless the replacement fully validates."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto cambia la fuente fijada del paquete, instala una versión anterior, o reemplaza código sin cambio de versión. El código existente permanece instalado a menos que el reemplazo se valide por completo."
+          }
+        }
+      }
+    },
+    "This clears Nuvio repositories, provider settings, repair history, and code owned only by the current Services profile. Other profiles' referenced code is preserved.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This clears Nuvio repositories, provider settings, repair history, and code owned only by the current Services profile. Other profiles' referenced code is preserved."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto borra los repositorios de Nuvio, ajustes de proveedor, historial de reparación y código que pertenece solo al perfil de Servicios actual. El código referenciado por otros perfiles se conserva."
+          }
+        }
+      }
+    },
+    "This device's media state needs recovery. Cloud uploads are paused and incoming sync is held to protect your other devices.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This device's media state needs recovery. Cloud uploads are paused and incoming sync is held to protect your other devices."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estado multimedia de este dispositivo necesita recuperación. Las subidas a la nube están pausadas y la sincronización entrante se retiene para proteger tus otros dispositivos."
           }
         }
       }
@@ -2759,6 +8475,97 @@
             "state": "translated",
             "value": "This downloaded episode will be permanently removed."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este episodio descargado se eliminará permanentemente."
+          }
+        }
+      }
+    },
+    "This is a kids profile, so it can see this plugin but not change or remove it. Switch to a grown-up profile to make those changes.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is a kids profile, so it can see this plugin but not change or remove it. Switch to a grown-up profile to make those changes."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este es un perfil infantil, así que puede ver este plugin pero no cambiarlo ni eliminarlo. Cambia a un perfil de adulto para hacer esos cambios."
+          }
+        }
+      }
+    },
+    "This is a kids profile, so it cannot add, edit, or remove profiles. Switch to a grown-up profile to make those changes.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is a kids profile, so it cannot add, edit, or remove profiles. Switch to a grown-up profile to make those changes."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este es un perfil infantil, así que no puede agregar, editar ni eliminar perfiles. Cambia a un perfil de adulto para hacer esos cambios."
+          }
+        }
+      }
+    },
+    "This package is pinned to a different source, is older, or changed code without a version bump. Existing code remains installed unless the replacement fully validates.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This package is pinned to a different source, is older, or changed code without a version bump. Existing code remains installed unless the replacement fully validates."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este paquete está fijado a otra fuente, es más antiguo, o cambió código sin subir de versión. El código existente permanece instalado a menos que el reemplazo se valide por completo."
+          }
+        }
+      }
+    },
+    "This package runs third-party JavaScript and has not completed Eclipse compatibility testing. Eclipse will still isolate its storage, filter network access, verify package integrity, and reject non-VOD output.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This package runs third-party JavaScript and has not completed Eclipse compatibility testing. Eclipse will still isolate its storage, filter network access, verify package integrity, and reject non-VOD output."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este paquete ejecuta JavaScript de terceros y no ha completado las pruebas de compatibilidad de Eclipse. Aun así, Eclipse aislará su almacenamiento, filtrará el acceso a la red, verificará la integridad del paquete y rechazará resultados que no sean VOD."
+          }
+        }
+      }
+    },
+    "This profile's watch progress, library, and ratings are removed from this device and from your synced accounts. Downloads are shared and stay put.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This profile's watch progress, library, and ratings are removed from this device and from your synced accounts. Downloads are shared and stay put."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El progreso de visualización, biblioteca y calificaciones de este perfil se eliminan de este dispositivo y de tus cuentas sincronizadas. Las descargas son compartidas y permanecen intactas."
+          }
         }
       }
     },
@@ -2769,6 +8576,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "This program comes with no warranty, to the extent permitted by law."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este programa no ofrece garantía alguna, en la medida permitida por la ley."
+          }
+        }
+      }
+    },
+    "This removes every provider in the repository and its downloaded code.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes every provider in the repository and its downloaded code."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto elimina todos los proveedores del repositorio y su código descargado."
+          }
+        }
+      }
+    },
+    "This removes every saved SkyStream repository and installed package from this device. You can add them again afterwards.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes every saved SkyStream repository and installed package from this device. You can add them again afterwards."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto elimina todos los repositorios guardados de SkyStream y los paquetes instalados de este dispositivo. Puedes agregarlos de nuevo después."
+          }
+        }
+      }
+    },
+    "This removes the plugin, every sub-provider row, stored preferences, and its local payload.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes the plugin, every sub-provider row, stored preferences, and its local payload."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto elimina el plugin, todas las filas de subproveedores, las preferencias guardadas y su contenido local."
           }
         }
       }
@@ -2781,6 +8645,29 @@
             "state": "translated",
             "value": "This service doesn't have configurable settings."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este servicio no tiene ajustes configurables."
+          }
+        }
+      }
+    },
+    "This third-party package has not completed Eclipse compatibility testing. Install only if you trust its source.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This third-party package has not completed Eclipse compatibility testing. Install only if you trust its source."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este paquete de terceros no ha completado las pruebas de compatibilidad de Eclipse. Instálalo solo si confías en su fuente."
+          }
         }
       }
     },
@@ -2791,6 +8678,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will cancel all active downloads and remove all downloaded files. This action cannot be undone."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto cancelará todas las descargas activas y eliminará todos los archivos descargados. Esta acción no se puede deshacer."
           }
         }
       }
@@ -2803,6 +8696,12 @@
             "state": "translated",
             "value": "This will import your AniList lists as Eclipse collections and fill local watch/read progress without deleting or downgrading anything."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto importará tus listas de AniList como colecciones de Eclipse y completará el progreso local de visualización/lectura sin eliminar ni retroceder nada."
+          }
         }
       }
     },
@@ -2813,6 +8712,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will import your MAL lists as Eclipse collections and fill local watch/read progress without deleting or downgrading anything."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto importará tus listas de MAL como colecciones de Eclipse y completará el progreso local de visualización/lectura sin eliminar ni retroceder nada."
           }
         }
       }
@@ -2825,6 +8730,12 @@
             "state": "translated",
             "value": "This will import your Trakt watchlist and watched progress as Eclipse collections without deleting or downgrading anything."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto importará tu lista de seguimiento y progreso visto de Trakt como colecciones de Eclipse sin eliminar ni retroceder nada."
+          }
         }
       }
     },
@@ -2835,6 +8746,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will overwrite your current settings, collections, watch progress, tracker logins including MAL, and service configurations with the backup data. Continue?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto sobrescribirá tus ajustes actuales, colecciones, progreso de visualización, inicios de sesión de rastreadores (incluido MAL) y configuraciones de servicios con los datos de la copia de seguridad. ¿Continuar?"
           }
         }
       }
@@ -2847,6 +8764,12 @@
             "state": "translated",
             "value": "This will remove all completed download files. This action cannot be undone."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto eliminará todos los archivos de descargas completadas. Esta acción no se puede deshacer."
+          }
         }
       }
     },
@@ -2857,6 +8780,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will remove cached files. You may need to re-download some content later."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto eliminará los archivos en caché. Es posible que debas volver a descargar algún contenido más adelante."
           }
         }
       }
@@ -2869,6 +8798,12 @@
             "state": "translated",
             "value": "This writes progress to the selected destination but never deletes entries or downgrades progress."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto escribe el progreso en el destino seleccionado, pero nunca elimina entradas ni retrocede el progreso."
+          }
         }
       }
     },
@@ -2879,6 +8814,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Threshold (0.0 - 1.0)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbral (0.0 - 1.0)"
           }
         }
       }
@@ -2891,6 +8832,29 @@
             "state": "translated",
             "value": "Timezone"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zona horaria"
+          }
+        }
+      }
+    },
+    "Tips": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tips"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consejos"
+          }
         }
       }
     },
@@ -2901,6 +8865,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Trackers"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rastreadores"
           }
         }
       }
@@ -2913,71 +8883,11 @@
             "state": "translated",
             "value": "Trakt Features"
           }
-        }
-      }
-    },
-    "Trakt list URL or ID": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trakt list URL or ID"
-          }
-        }
-      }
-    },
-    "Trakt Public Catalogs": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trakt Public Catalogs"
-          }
-        }
-      }
-    },
-    "Trakt Reviews": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trakt Reviews"
-          }
-        }
-      }
-    },
-    "Try adjusting your filter or search for something else": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try adjusting your filter or search for something else"
-          }
-        }
-      }
-    },
-    "Try Again": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try Again"
-          }
-        }
-      }
-    },
-    "Try searching for a different movie or TV show": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try searching for a different movie or TV show"
+            "value": "Funciones de Trakt"
           }
         }
       }
@@ -2990,6 +8900,352 @@
             "state": "translated",
             "value": "Type"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo de lista de Trakt"
+          }
+        }
+      }
+    },
+    "Trakt Public Catalogs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trakt Public Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogos públicos de Trakt"
+          }
+        }
+      }
+    },
+    "Trakt Reviews": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trakt Reviews"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reseñas de Trakt"
+          }
+        }
+      }
+    },
+    "Trakt list URL or ID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trakt list URL or ID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL o ID de lista de Trakt"
+          }
+        }
+      }
+    },
+    "Translations are community-contributed and still a work in progress, so some screens may still show English text. Eclipse applies the interface language the next time it launches.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Translations are community-contributed and still a work in progress, so some screens may still show English text. Eclipse applies the interface language the next time it launches."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las traducciones son aportadas por la comunidad y siguen en progreso, así que algunas pantallas pueden seguir mostrando texto en inglés. Eclipse aplica el idioma de la interfaz la próxima vez que se inicie."
+          }
+        }
+      }
+    },
+    "Treat Dubbed Anime Streams as English": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Treat Dubbed Anime Streams as English"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tratar transmisiones de anime dobladas como inglés"
+          }
+        }
+      }
+    },
+    "Try Again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try Again"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intentar de nuevo"
+          }
+        }
+      }
+    },
+    "Try a setting name, feature, or service.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try a setting name, feature, or service."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intenta con el nombre de un ajuste, función o servicio."
+          }
+        }
+      }
+    },
+    "Try adjusting your filter or search for something else": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try adjusting your filter or search for something else"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intenta ajustar el filtro o busca otra cosa"
+          }
+        }
+      }
+    },
+    "Try searching for a different movie or TV show": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try searching for a different movie or TV show"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intenta buscar otra película o serie"
+          }
+        }
+      }
+    },
+    "Turn Auto Quality off when you want to choose stream quality yourself. Error Intelligence skips sources that are known to be unavailable.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn Auto Quality off when you want to choose stream quality yourself. Error Intelligence skips sources that are known to be unavailable."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactiva la calidad automática cuando quieras elegir tú mismo la calidad de transmisión. La inteligencia de errores omite fuentes que se sabe que no están disponibles."
+          }
+        }
+      }
+    },
+    "Turn Back On": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn Back On"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a activar"
+          }
+        }
+      }
+    },
+    "Turn On & Join": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn On & Join"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar y unirse"
+          }
+        }
+      }
+    },
+    "UTC": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "UTC"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "UTC"
+          }
+        }
+      }
+    },
+    "Unable to Load": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to Load"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo cargar"
+          }
+        }
+      }
+    },
+    "Uninstall": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
+          }
+        }
+      }
+    },
+    "Uninstall Plugin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall Plugin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar plugin"
+          }
+        }
+      }
+    },
+    "Uninstall Plugin?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall Plugin?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Desinstalar plugin?"
+          }
+        }
+      }
+    },
+    "Uninstalling removes the whole package and all of its provider rows.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstalling removes the whole package and all of its provider rows."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar elimina todo el paquete y todas sus filas de proveedor."
+          }
+        }
+      }
+    },
+    "Untested Plugin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untested Plugin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plugin sin probar"
+          }
+        }
+      }
+    },
+    "Update Available": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Available"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización disponible"
+          }
         }
       }
     },
@@ -3000,6 +9256,165 @@
           "stringUnit": {
             "state": "translated",
             "value": "Update URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar URL"
+          }
+        }
+      }
+    },
+    "Update provenance is frozen": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update provenance is frozen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La procedencia de la actualización está congelada"
+          }
+        }
+      }
+    },
+    "Updating results": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updating results"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando resultados"
+          }
+        }
+      }
+    },
+    "Use My Other Devices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use My Other Devices"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar mis otros dispositivos"
+          }
+        }
+      }
+    },
+    "Use My Other Devices applies the settings already shared across your account. Use This Apple TV shares this device's current settings with your other devices. Settings sync stays off until you choose.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use My Other Devices applies the settings already shared across your account. Use This Apple TV shares this device's current settings with your other devices. Settings sync stays off until you choose."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"Usar mis otros dispositivos\" aplica los ajustes ya compartidos en tu cuenta. \"Usar este Apple TV\" comparte los ajustes actuales de este dispositivo con tus otros dispositivos. La sincronización de ajustes permanece apagada hasta que elijas."
+          }
+        }
+      }
+    },
+    "Use This Apple TV": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use This Apple TV"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar este Apple TV"
+          }
+        }
+      }
+    },
+    "Use This Device": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use This Device"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar este dispositivo"
+          }
+        }
+      }
+    },
+    "Use the arrow buttons to change section order. Hidden rows will not appear on media detail pages.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the arrow buttons to change section order. Hidden rows will not appear on media detail pages."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa los botones de flecha para cambiar el orden de las secciones. Las filas ocultas no aparecerán en las páginas de detalle."
+          }
+        }
+      }
+    },
+    "Verified VOD": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verified VOD"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VOD verificado"
+          }
+        }
+      }
+    },
+    "Verify Cloudflare": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verify Cloudflare"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar Cloudflare"
           }
         }
       }
@@ -3012,6 +9427,46 @@
             "state": "translated",
             "value": "View"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver"
+          }
+        }
+      }
+    },
+    "Waiting for the Host": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for the Host"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperando al anfitrión"
+          }
+        }
+      }
+    },
+    "Waiting for you to approve sign-in…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for you to approve sign-in…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperando a que apruebes el inicio de sesión…"
+          }
         }
       }
     },
@@ -3022,6 +9477,131 @@
           "stringUnit": {
             "state": "translated",
             "value": "Watch Now"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver ahora"
+          }
+        }
+      }
+    },
+    "Watch Together": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Watch Together"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver juntos"
+          }
+        }
+      }
+    },
+    "Watch Together is Off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Watch Together is Off"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver juntos está apagado"
+          }
+        }
+      }
+    },
+    "Watched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visto"
+          }
+        }
+      }
+    },
+    "Welcome back": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome back"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bienvenido de nuevo"
+          }
+        }
+      }
+    },
+    "Which Settings Should Win?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Which Settings Should Win?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Qué ajustes deben prevalecer?"
+          }
+        }
+      }
+    },
+    "Which profile is yours?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Which profile is yours?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Cuál perfil es el tuyo?"
+          }
+        }
+      }
+    },
+    "You closed the shared title while SharePlay is still active. Leaving stops syncing with the group on this device.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You closed the shared title while SharePlay is still active. Leaving stops syncing with the group on this device."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerraste el título compartido mientras SharePlay sigue activo. Salir detiene la sincronización con el grupo en este dispositivo."
           }
         }
       }
@@ -3034,6 +9614,12 @@
             "state": "translated",
             "value": "You don't have any active services, Stremio addons, or plugins. Add or enable a source in Settings."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tienes servicios activos, addons de Stremio ni plugins. Agrega o activa una fuente en Ajustes."
+          }
         }
       }
     },
@@ -3045,6 +9631,148 @@
             "state": "translated",
             "value": "You don't have any active services. Please go to the Services tab to download and activate services."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tienes servicios activos. Ve a la pestaña Servicios para descargar y activar servicios."
+          }
+        }
+      }
+    },
+    "You don't have any active sources. Open Services settings to add or enable one.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You don't have any active sources. Open Services settings to add or enable one."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tienes fuentes activas. Abre los ajustes de Servicios para agregar o activar una."
+          }
+        }
+      }
+    },
+    "You joined the Watch Together session, but the host's Eclipse hasn't responded yet. Ask them to open Eclipse with their video playing.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You joined the Watch Together session, but the host's Eclipse hasn't responded yet. Ask them to open Eclipse with their video playing."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Te uniste a la sesión de Ver juntos, pero el Eclipse del anfitrión aún no ha respondido. Pídele que abra Eclipse con su video reproduciéndose."
+          }
+        }
+      }
+    },
+    "Your Other Devices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Other Devices"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus otros dispositivos"
+          }
+        }
+      }
+    },
+    "Your name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu nombre"
+          }
+        }
+      }
+    },
+    "Your profiles came back with your data. Pick the one to open Eclipse with.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your profiles came back with your data. Pick the one to open Eclipse with."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus perfiles regresaron con tus datos. Elige con cuál abrir Eclipse."
+          }
+        }
+      }
+    },
+    "Your settings may have changed on this device while syncing was off. \"Use My Other Devices\" replaces this device's settings with the ones already shared across your account. \"Use This Device\" makes these settings the shared ones and updates your other devices. Settings sync stays off until you choose.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your settings may have changed on this device while syncing was off. \"Use My Other Devices\" replaces this device's settings with the ones already shared across your account. \"Use This Device\" makes these settings the shared ones and updates your other devices. Settings sync stays off until you choose."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus ajustes pueden haber cambiado en este dispositivo mientras la sincronización estaba apagada. \\\"Usar mis otros dispositivos\\\" reemplaza los ajustes de este dispositivo con los ya compartidos en tu cuenta. \\\"Usar este dispositivo\\\" hace que estos ajustes sean los compartidos y actualiza tus otros dispositivos. La sincronización de ajustes permanece apagada hasta que elijas."
+          }
+        }
+      }
+    },
+    "iCloud Sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización con iCloud"
+          }
+        }
+      }
+    },
+    "· Custom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· Custom"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· Personalizado"
+          }
         }
       }
     },
@@ -3055,6 +9783,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Visto"
           }
         }
       }

--- a/Eclipse/Localizable.xcstrings
+++ b/Eclipse/Localizable.xcstrings
@@ -1,6 +1,91 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "A PIN can be set once the profile exists.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A PIN can be set once the profile exists."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se puede configurar un PIN una vez que el perfil exista."
+          }
+        }
+      }
+    },
+    "A new Eclipse release is available on GitHub.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A new Eclipse release is available on GitHub."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hay una nueva versión de Eclipse disponible en GitHub."
+          }
+        }
+      }
+    },
+    "A player and a catalog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A player and a catalog."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un reproductor y un catálogo."
+          }
+        }
+      }
+    },
+    "A sync recovery point is waiting to finish. Cloud uploads stay paused until Eclipse completes it, usually at the next app activation.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A sync recovery point is waiting to finish. Cloud uploads stay paused until Eclipse completes it, usually at the next app activation."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hay un punto de recuperación de sincronización pendiente de terminar. Las subidas a la nube quedan pausadas hasta que Eclipse lo complete, normalmente en la siguiente activación de la app."
+          }
+        }
+      }
+    },
+    "About": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acerca de"
+          }
+        }
+      }
+    },
     "Accent Color": {
       "extractionState": "manual",
       "localizations": {
@@ -52,6 +137,23 @@
         }
       }
     },
+    "Add Nuvio Plugin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Nuvio Plugin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar plugin de Nuvio"
+          }
+        }
+      }
+    },
     "Add Service": {
       "extractionState": "manual",
       "localizations": {
@@ -69,6 +171,40 @@
         }
       }
     },
+    "Add SkyStream Plugin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add SkyStream Plugin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar plugin de SkyStream"
+          }
+        }
+      }
+    },
+    "Add Source": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Source"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar fuente"
+          }
+        }
+      }
+    },
     "Add Stremio Addon": {
       "extractionState": "manual",
       "localizations": {
@@ -82,6 +218,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Agregar addon de Stremio"
+          }
+        }
+      }
+    },
+    "Add a source": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a source"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar una fuente"
           }
         }
       }
@@ -150,6 +303,74 @@
           "stringUnit": {
             "state": "translated",
             "value": "Afecta botones, enlaces y otros elementos interactivos."
+          }
+        }
+      }
+    },
+    "Already use Eclipse?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Already use Eclipse?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Ya usas Eclipse?"
+          }
+        }
+      }
+    },
+    "AniList": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList"
+          }
+        }
+      }
+    },
+    "AniList Unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList Unavailable"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList no disponible"
+          }
+        }
+      }
+    },
+    "AniList appears to be down. Eclipse is switching to MyAnimeList fallback for anime metadata. Season and special mapping should still work, but may be less accurate until AniList recovers.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList appears to be down. Eclipse is switching to MyAnimeList fallback for anime metadata. Season and special mapping should still work, but may be less accurate until AniList recovers."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AniList parece estar caído. Eclipse está cambiando a MyAnimeList como respaldo para los metadatos de anime. El mapeo de temporadas y especiales debería seguir funcionando, pero puede ser menos preciso hasta que AniList se recupere."
           }
         }
       }
@@ -239,6 +460,57 @@
         }
       }
     },
+    "Apply Extra Rules To": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply Extra Rules To"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar reglas adicionales a"
+          }
+        }
+      }
+    },
+    "Apply to All Connected Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply to All Connected Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar a todas las fuentes conectadas"
+          }
+        }
+      }
+    },
+    "Apply to Home Screen": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply to Home Screen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicar a la pantalla de inicio"
+          }
+        }
+      }
+    },
     "Ascending": {
       "extractionState": "manual",
       "localizations": {
@@ -256,6 +528,40 @@
         }
       }
     },
+    "Assume Original Language for Untagged Streams": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assume Original Language for Untagged Streams"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asumir idioma original para transmisiones sin etiquetar"
+          }
+        }
+      }
+    },
+    "At least one grown-up profile has to stay. Kids profiles can't add, edit, or delete profiles, so turning this one into a kids profile would leave nobody able to change it back.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "At least one grown-up profile has to stay. Kids profiles can't add, edit, or delete profiles, so turning this one into a kids profile would leave nobody able to change it back."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debe quedar al menos un perfil de adulto. Los perfiles infantiles no pueden agregar, editar ni eliminar perfiles, así que convertir este en perfil infantil dejaría a nadie que pudiera revertirlo."
+          }
+        }
+      }
+    },
     "Auto Mode": {
       "extractionState": "manual",
       "localizations": {
@@ -269,6 +575,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modo automático"
+          }
+        }
+      }
+    },
+    "Auto Mode Error Intelligence": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Mode Error Intelligence"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inteligencia de errores del modo automático"
+          }
+        }
+      }
+    },
+    "Auto Mode checks included, enabled sources from top to bottom. Drag to set priority. Include All and Exclude All also update installed sources that are currently disabled on this device, without changing sources that exist only on another platform.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Mode checks included, enabled sources from top to bottom. Drag to set priority. Include All and Exclude All also update installed sources that are currently disabled on this device, without changing sources that exist only on another platform."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El modo automático revisa las fuentes incluidas y activadas de arriba hacia abajo. Arrastra para establecer la prioridad. Incluir todo y Excluir todo también actualizan las fuentes instaladas que están desactivadas en este dispositivo, sin cambiar las fuentes que solo existen en otra plataforma."
+          }
+        }
+      }
+    },
+    "Auto Mode checks included, enabled sources from top to bottom. Use the arrow buttons to set priority. Include All and Exclude All also update installed sources that are currently disabled on this Apple TV, without changing sources that exist only on another platform.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Mode checks included, enabled sources from top to bottom. Use the arrow buttons to set priority. Include All and Exclude All also update installed sources that are currently disabled on this Apple TV, without changing sources that exist only on another platform."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El modo automático revisa las fuentes incluidas y activadas de arriba hacia abajo. Usa los botones de flecha para establecer la prioridad. Incluir todo y Excluir todo también actualizan las fuentes instaladas que están desactivadas en este Apple TV, sin cambiar las fuentes que solo existen en otra plataforma."
           }
         }
       }
@@ -324,6 +681,23 @@
         }
       }
     },
+    "Auto-Select Episodes also applies when choosing a source manually.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Select Episodes also applies when choosing a source manually."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La selección automática de episodios también aplica al elegir una fuente manualmente."
+          }
+        }
+      }
+    },
     "Auto-Select Episodes also applies when choosing a source manually. Auto Mode checks enabled sources from top to bottom. Drag to set priority, and turn Auto Quality off when you want to choose stream quality yourself.": {
       "extractionState": "manual",
       "localizations": {
@@ -358,6 +732,23 @@
         }
       }
     },
+    "Auto-Update Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Update Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar fuentes automáticamente"
+          }
+        }
+      }
+    },
     "Auto-check GitHub Releases": {
       "extractionState": "manual",
       "localizations": {
@@ -388,6 +779,108 @@
           "stringUnit": {
             "state": "translated",
             "value": "Busca actualizaciones de servicios automáticamente al abrir la app."
+          }
+        }
+      }
+    },
+    "Automatically check for source updates when the app is opened.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically check for source updates when the app is opened."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busca actualizaciones de fuentes automáticamente al abrir la app."
+          }
+        }
+      }
+    },
+    "Automatically keep selected Eclipse data in sync through iCloud, Google Drive, or OneDrive.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically keep selected Eclipse data in sync through iCloud, Google Drive, or OneDrive."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantiene los datos seleccionados de Eclipse sincronizados automáticamente mediante iCloud, Google Drive o OneDrive."
+          }
+        }
+      }
+    },
+    "Available": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponible"
+          }
+        }
+      }
+    },
+    "Available only when playing with MPV's MoltenVK renderer. The player button stays hidden in AVPlayer and while this setting is off.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available only when playing with MPV's MoltenVK renderer. The player button stays hidden in AVPlayer and while this setting is off."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponible solo al reproducir con el motor MoltenVK de MPV. El botón del reproductor permanece oculto en AVPlayer y mientras este ajuste esté apagado."
+          }
+        }
+      }
+    },
+    "Back": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrás"
+          }
+        }
+      }
+    },
+    "Back to Library": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back to Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a la biblioteca"
           }
         }
       }
@@ -443,6 +936,91 @@
         }
       }
     },
+    "Behavior": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Behavior"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comportamiento"
+          }
+        }
+      }
+    },
+    "Best-effort stream rules for the selected sources. An Include list only keeps streams with a matching detected language; Exclude takes priority when the same language appears in both lists. When Assume Original Language for Untagged Streams is enabled, a stream with no language data is evaluated using the media's TMDB original language before Include and Exclude rules run. When Treat Dubbed Anime Streams as English is enabled, anime streams labeled dubbed or dub match English filters and count as having language data. Quality and language detection use stream tags, filenames, and labels; a stream URL contributes only its path, and two-letter codes count only when a source reports them as language data.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Best-effort stream rules for the selected sources. An Include list only keeps streams with a matching detected language; Exclude takes priority when the same language appears in both lists. When Assume Original Language for Untagged Streams is enabled, a stream with no language data is evaluated using the media's TMDB original language before Include and Exclude rules run. When Treat Dubbed Anime Streams as English is enabled, anime streams labeled dubbed or dub match English filters and count as having language data. Quality and language detection use stream tags, filenames, and labels; a stream URL contributes only its path, and two-letter codes count only when a source reports them as language data."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reglas de mejor esfuerzo para las transmisiones de las fuentes seleccionadas. Una lista de Incluir solo conserva transmisiones con un idioma detectado que coincida; Excluir tiene prioridad cuando el mismo idioma aparece en ambas listas. Cuando \"Asumir idioma original para transmisiones sin etiquetar\" está activado, una transmisión sin datos de idioma se evalúa usando el idioma original de TMDB antes de aplicar las reglas de Incluir y Excluir. Cuando \"Tratar transmisiones de anime dobladas como inglés\" está activado, las transmisiones de anime etiquetadas como dobladas cuentan como si tuvieran datos de idioma en inglés. La detección de calidad e idioma usa etiquetas, nombres de archivo y etiquetas de la transmisión; una URL de transmisión solo aporta su ruta, y los códigos de dos letras solo cuentan cuando una fuente los reporta como datos de idioma."
+          }
+        }
+      }
+    },
+    "Block Add-on Catalogs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block Add-on Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquear catálogos de addons"
+          }
+        }
+      }
+    },
+    "Block Add-on Subtitles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Block Add-on Subtitles"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloquear subtítulos de addons"
+          }
+        }
+      }
+    },
+    "Browse": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explorar"
+          }
+        }
+      }
+    },
     "Cancel": {
       "extractionState": "manual",
       "localizations": {
@@ -473,6 +1051,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cancelar todo lo activo"
+          }
+        }
+      }
+    },
+    "Cancel Sign-In": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel Sign-In"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar inicio de sesión"
+          }
+        }
+      }
+    },
+    "Card Info": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Card Info"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Información de la tarjeta"
           }
         }
       }
@@ -545,6 +1157,108 @@
         }
       }
     },
+    "Change": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar"
+          }
+        }
+      }
+    },
+    "Changes are blocked": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes are blocked"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los cambios están bloqueados"
+          }
+        }
+      }
+    },
+    "Check for Update": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Update"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualización"
+          }
+        }
+      }
+    },
+    "Checking this title...": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking this title..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificando este título..."
+          }
+        }
+      }
+    },
+    "Choose a day": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a day"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un día"
+          }
+        }
+      }
+    },
+    "Choose a preset with the remote. A custom color synced from another device remains in use until you select a preset.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a preset with the remote. A custom color synced from another device remains in use until you select a preset."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un valor predeterminado con el control remoto. Un color personalizado sincronizado desde otro dispositivo se mantiene en uso hasta que selecciones un valor predeterminado."
+          }
+        }
+      }
+    },
     "Choose a server to stream from": {
       "extractionState": "manual",
       "localizations": {
@@ -592,6 +1306,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Elige un episodio:"
+          }
+        }
+      }
+    },
+    "Choose an optional way to support Eclipse.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose an optional way to support Eclipse."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una forma opcional de apoyar a Eclipse."
+          }
+        }
+      }
+    },
+    "Choose how Eclipse automatically selects sources, episodes, and stream quality.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose how Eclipse automatically selects sources, episodes, and stream quality."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige cómo Eclipse selecciona automáticamente fuentes, episodios y calidad de transmisión."
+          }
+        }
+      }
+    },
+    "Choose what Eclipse should check for on this device.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose what Eclipse should check for on this device."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige qué debe verificar Eclipse en este dispositivo."
           }
         }
       }
@@ -647,6 +1412,23 @@
         }
       }
     },
+    "Clear All": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar todo"
+          }
+        }
+      }
+    },
     "Clear All Logs": {
       "extractionState": "manual",
       "localizations": {
@@ -681,6 +1463,40 @@
         }
       }
     },
+    "Clear Excluded Languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Excluded Languages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar idiomas excluidos"
+          }
+        }
+      }
+    },
+    "Clear Included Languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Included Languages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar idiomas incluidos"
+          }
+        }
+      }
+    },
     "Clear Reader Logs": {
       "extractionState": "manual",
       "localizations": {
@@ -694,6 +1510,108 @@
           "stringUnit": {
             "state": "translated",
             "value": "Borrar registros del lector"
+          }
+        }
+      }
+    },
+    "Close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
+          }
+        }
+      }
+    },
+    "Cloud Sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización en la nube"
+          }
+        }
+      }
+    },
+    "Cloud Sync & Cache": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Sync & Cache"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización en la nube y caché"
+          }
+        }
+      }
+    },
+    "Cloud Sync Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Sync Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de sincronización en la nube"
+          }
+        }
+      }
+    },
+    "Cloud Sync starts off. Turning it on stores library, playback progress, TV-safe preferences, supported installed-source configuration, and tracker sign-ins in your private iCloud database. Turning it off stops syncing without deleting either copy. Cloud-provider login tokens, ephemeral playback URLs, and session cookies stay local.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Sync starts off. Turning it on stores library, playback progress, TV-safe preferences, supported installed-source configuration, and tracker sign-ins in your private iCloud database. Turning it off stops syncing without deleting either copy. Cloud-provider login tokens, ephemeral playback URLs, and session cookies stay local."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sincronización en la nube empieza apagada. Activarla guarda la biblioteca, el progreso de reproducción, las preferencias seguras para TV, la configuración de fuentes instaladas compatibles y los inicios de sesión de rastreadores en tu base de datos privada de iCloud. Desactivarla detiene la sincronización sin borrar ninguna de las dos copias. Los tokens de inicio de sesión del proveedor de la nube, las URLs temporales de reproducción y las cookies de sesión permanecen locales."
+          }
+        }
+      }
+    },
+    "Cloud sync is on. \"This Device Only\" turns every cloud provider off on this device before restoring, keeps the complete restored backup here, and leaves the cloud copy and your other devices unchanged. Sync stays off here until you turn a provider on again. \"Replace Everywhere\" keeps your current provider choices and makes this backup authoritative after the restore finishes, replacing newer cloud changes, including progress recorded since the backup was made.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud sync is on. \"This Device Only\" turns every cloud provider off on this device before restoring, keeps the complete restored backup here, and leaves the cloud copy and your other devices unchanged. Sync stays off here until you turn a provider on again. \"Replace Everywhere\" keeps your current provider choices and makes this backup authoritative after the restore finishes, replacing newer cloud changes, including progress recorded since the backup was made."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sincronización en la nube está activada. \\\"Solo este dispositivo\\\" desactiva todos los proveedores de nube en este dispositivo antes de restaurar, conserva aquí la copia de seguridad restaurada completa, y deja sin cambios la copia en la nube y tus otros dispositivos. La sincronización queda apagada aquí hasta que actives un proveedor de nuevo. \\\"Reemplazar en todos lados\\\" conserva tus proveedores actuales y hace que esta copia de seguridad sea la autoritativa después de restaurar, reemplazando cambios más recientes en la nube, incluido el progreso registrado desde que se hizo la copia."
           }
         }
       }
@@ -868,6 +1786,40 @@
         }
       }
     },
+    "Configured manifest URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configured manifest URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del manifiesto configurado"
+          }
+        }
+      }
+    },
+    "Confirm Code Replacement": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm Code Replacement"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar reemplazo de código"
+          }
+        }
+      }
+    },
     "Connect": {
       "extractionState": "manual",
       "localizations": {
@@ -885,6 +1837,40 @@
         }
       }
     },
+    "Connect Trakt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect Trakt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar Trakt"
+          }
+        }
+      }
+    },
+    "Connect on iPhone or iPad": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect on iPhone or iPad"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar en iPhone o iPad"
+          }
+        }
+      }
+    },
     "Connection Error": {
       "extractionState": "manual",
       "localizations": {
@@ -898,6 +1884,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Error de conexión"
+          }
+        }
+      }
+    },
+    "Content Blocking": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Content Blocking"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueo de contenido"
           }
         }
       }
@@ -936,6 +1939,108 @@
         }
       }
     },
+    "Copy Stream URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Stream URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar URL de la transmisión"
+          }
+        }
+      }
+    },
+    "Could not refresh results": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not refresh results"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron actualizar los resultados"
+          }
+        }
+      }
+    },
+    "Couldn't Find a Random Title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't Find a Random Title"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo encontrar un título aleatorio"
+          }
+        }
+      }
+    },
+    "Couldn't Remove Plugin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't Remove Plugin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo quitar el plugin"
+          }
+        }
+      }
+    },
+    "Couldn't Update All Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't Update All Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron actualizar todas las fuentes"
+          }
+        }
+      }
+    },
+    "Could’nt Update History": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could’nt Update History"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo actualizar el historial"
+          }
+        }
+      }
+    },
     "Create": {
       "extractionState": "manual",
       "localizations": {
@@ -966,6 +2071,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Crear nueva colección"
+          }
+        }
+      }
+    },
+    "Create your profile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create your profile"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea tu perfil"
+          }
+        }
+      }
+    },
+    "Current Color": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current Color"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color actual"
           }
         }
       }
@@ -1021,6 +2160,23 @@
         }
       }
     },
+    "Customize": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Customize"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizar"
+          }
+        }
+      }
+    },
     "Data": {
       "extractionState": "manual",
       "localizations": {
@@ -1034,6 +2190,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Datos"
+          }
+        }
+      }
+    },
+    "Decrease": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrease"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disminuir"
+          }
+        }
+      }
+    },
+    "Decrease Size": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrease Size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disminuir tamaño"
           }
         }
       }
@@ -1225,6 +2415,23 @@
         }
       }
     },
+    "Diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostics"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico"
+          }
+        }
+      }
+    },
     "Direction": {
       "extractionState": "manual",
       "localizations": {
@@ -1238,6 +2445,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dirección"
+          }
+        }
+      }
+    },
+    "Disable All Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable All Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivar todas las fuentes"
           }
         }
       }
@@ -1272,6 +2496,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Desconectar"
+          }
+        }
+      }
+    },
+    "Dismiss": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar"
           }
         }
       }
@@ -1344,6 +2585,176 @@
         }
       }
     },
+    "Drop Unmatched Search Results": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drop Unmatched Search Results"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar resultados de búsqueda sin coincidencia"
+          }
+        }
+      }
+    },
+    "Earlier versions of Eclipse automatically synced your library and watch progress through iCloud on this device. That sync is now off, and no data was deleted. You can keep it off or explicitly resume syncing.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Earlier versions of Eclipse automatically synced your library and watch progress through iCloud on this device. That sync is now off, and no data was deleted. You can keep it off or explicitly resume syncing."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versiones anteriores de Eclipse sincronizaban automáticamente tu biblioteca y progreso de visualización mediante iCloud en este dispositivo. Esa sincronización ahora está apagada y no se eliminó ningún dato. Puedes dejarla apagada o reanudarla explícitamente."
+          }
+        }
+      }
+    },
+    "Eclipse": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse"
+          }
+        }
+      }
+    },
+    "Eclipse Player": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse Player"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproductor de Eclipse"
+          }
+        }
+      }
+    },
+    "Eclipse could not change the settings-sync direction while a restore, account change, or recovery is still active. Settings sync remains off. Wait for Cloud Sync to become ready, then try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not change the settings-sync direction while a restore, account change, or recovery is still active. Settings sync remains off. Wait for Cloud Sync to become ready, then try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo cambiar la dirección de sincronización de ajustes mientras una restauración, cambio de cuenta o recuperación sigue activa. La sincronización de ajustes permanece apagada. Espera a que la sincronización en la nube esté lista y vuelve a intentarlo."
+          }
+        }
+      }
+    },
+    "Eclipse could not finish recovery and left the recovery point in place. Stop playback or relaunch the app, then try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not finish recovery and left the recovery point in place. Stop playback or relaunch the app, then try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo terminar la recuperación y dejó el punto de recuperación en su lugar. Detén la reproducción o reinicia la app y vuelve a intentarlo."
+          }
+        }
+      }
+    },
+    "Eclipse could not finish the recovery and left the recovery point in place. Try again after relaunching the app.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not finish the recovery and left the recovery point in place. Try again after relaunching the app."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo terminar la recuperación y dejó el punto de recuperación en su lugar. Vuelve a intentarlo después de reiniciar la app."
+          }
+        }
+      }
+    },
+    "Eclipse could not read the installed Nuvio data, so it preserved the original bytes instead of replacing them. Restore a valid backup or explicitly reset Nuvio plugin data before making changes.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not read the installed Nuvio data, so it preserved the original bytes instead of replacing them. Restore a valid backup or explicitly reset Nuvio plugin data before making changes."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo leer los datos instalados de Nuvio, así que conservó los bytes originales en lugar de reemplazarlos. Restaura una copia de seguridad válida o restablece explícitamente los datos del plugin de Nuvio antes de hacer cambios."
+          }
+        }
+      }
+    },
+    "Eclipse could not safely apply that choice. Settings sync is still off. Wait for the current account or sync operation to finish, then try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not safely apply that choice. Settings sync is still off. Wait for the current account or sync operation to finish, then try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo aplicar esa elección de forma segura. La sincronización de ajustes sigue apagada. Espera a que termine la operación actual de cuenta o sincronización y vuelve a intentarlo."
+          }
+        }
+      }
+    },
+    "Eclipse could not save that change. Your notification history and the matching iOS alert were left intact.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse could not save that change. Your notification history and the matching iOS alert were left intact."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no pudo guardar ese cambio. Tu historial de notificaciones y la alerta de iOS correspondiente quedaron intactos."
+          }
+        }
+      }
+    },
     "Eclipse is a GPL-licensed media app with substantial original changes by Soupy-dev.": {
       "extractionState": "manual",
       "localizations": {
@@ -1357,6 +2768,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eclipse es una app multimedia con licencia GPL, con cambios originales considerables realizados por Soupy-dev."
+          }
+        }
+      }
+    },
+    "Eclipse is not responsible for changes, loss, restrictions, suspension, or other issues affecting your chosen cloud service. Use Cloud Sync at your own risk. iCloud, Google Drive, OneDrive, Apple, Google, and Microsoft are trademarks of their respective owners and are not affiliated with Eclipse.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse is not responsible for changes, loss, restrictions, suspension, or other issues affecting your chosen cloud service. Use Cloud Sync at your own risk. iCloud, Google Drive, OneDrive, Apple, Google, and Microsoft are trademarks of their respective owners and are not affiliated with Eclipse."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no es responsable de cambios, pérdidas, restricciones, suspensiones u otros problemas que afecten al servicio de nube que elijas. Usa la sincronización en la nube bajo tu propio riesgo. iCloud, Google Drive, OneDrive, Apple, Google y Microsoft son marcas de sus respectivos dueños y no están afiliadas con Eclipse."
           }
         }
       }
@@ -1378,6 +2806,57 @@
         }
       }
     },
+    "Eclipse kept a recovery point from before the interrupted account change. Restoring it replaces this device's media state with that recovery point and resumes sync. The unreadable data stays on this device.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse kept a recovery point from before the interrupted account change. Restoring it replaces this device's media state with that recovery point and resumes sync. The unreadable data stays on this device."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse conservó un punto de recuperación de antes del cambio de cuenta interrumpido. Restaurarlo reemplaza el estado multimedia de este dispositivo con ese punto de recuperación y reanuda la sincronización. Los datos ilegibles permanecen en este dispositivo."
+          }
+        }
+      }
+    },
+    "Eclipse ships with none. Playback needs one you add.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse ships with none. Playback needs one you add."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no incluye ninguna. La reproducción necesita una que agregues tú."
+          }
+        }
+      }
+    },
+    "Eclipse ships without content sources. Add a Service or Stremio addon in Settings › Services, then come back to play this title.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse ships without content sources. Add a Service or Stremio addon in Settings › Services, then come back to play this title."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse no incluye fuentes de contenido. Agrega un servicio o addon de Stremio en Ajustes › Servicios y regresa para reproducir este título."
+          }
+        }
+      }
+    },
     "Eclipse's privacy policy explains what data the app stores locally and how optional third-party services are handled.": {
       "extractionState": "manual",
       "localizations": {
@@ -1391,6 +2870,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "La política de privacidad de Eclipse explica qué datos almacena la app localmente y cómo se gestionan los servicios opcionales de terceros."
+          }
+        }
+      }
+    },
+    "Edit Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar ajustes"
           }
         }
       }
@@ -1412,6 +2908,40 @@
         }
       }
     },
+    "Enable All Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable All Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar todas las fuentes"
+          }
+        }
+      }
+    },
+    "Enable Better Posters": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Better Posters"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar Better Posters"
+          }
+        }
+      }
+    },
     "Enable Sync": {
       "extractionState": "manual",
       "localizations": {
@@ -1429,6 +2959,74 @@
         }
       }
     },
+    "Enable Watch Together": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Watch Together"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar Ver juntos"
+          }
+        }
+      }
+    },
+    "Enable at least one catalog in Settings to populate your home screen.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable at least one catalog in Settings to populate your home screen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa al menos un catálogo en Ajustes para llenar tu pantalla de inicio."
+          }
+        }
+      }
+    },
+    "Enable at least one stream-capable source to set its priority.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable at least one stream-capable source to set its priority."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa al menos una fuente compatible con transmisión para establecer su prioridad."
+          }
+        }
+      }
+    },
+    "Enable or disable content catalogs and use the arrow buttons to reorder them. The order here determines the order on your home screen. Use Customize to override orientation, size, and card info per catalog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable or disable content catalogs and use the arrow buttons to reorder them. The order here determines the order on your home screen. Use Customize to override orientation, size, and card info per catalog."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva los catálogos de contenido y usa los botones de flecha para reordenarlos. El orden aquí determina el orden en tu pantalla de inicio. Usa Personalizar para anular orientación, tamaño e información de tarjeta por catálogo."
+          }
+        }
+      }
+    },
     "Enable/disable content catalogs and drag to reorder them. The order here determines the order on your home screen. Stremio catalog addons may reduce performance or have visual inconsistencies. Trakt catalogs appear after Trakt is connected.": {
       "extractionState": "manual",
       "localizations": {
@@ -1442,6 +3040,91 @@
           "stringUnit": {
             "state": "translated",
             "value": "Activa o desactiva los catálogos de contenido y arrástralos para reordenarlos. El orden aquí determina el orden en tu pantalla de inicio. Los addons de catálogo de Stremio pueden reducir el rendimiento o tener inconsistencias visuales. Los catálogos de Trakt aparecen después de conectar Trakt."
+          }
+        }
+      }
+    },
+    "Enable/disable content catalogs and drag to reorder them. The order here determines the order on your home screen. Tap the slider icon to customize orientation, size, and card info for a single catalog. Stremio catalog addons may reduce performance or have visual inconsistencies. Trakt catalogs appear after Trakt is connected.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable/disable content catalogs and drag to reorder them. The order here determines the order on your home screen. Tap the slider icon to customize orientation, size, and card info for a single catalog. Stremio catalog addons may reduce performance or have visual inconsistencies. Trakt catalogs appear after Trakt is connected."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva los catálogos de contenido y arrástralos para reordenarlos. El orden aquí determina el orden en tu pantalla de inicio. Toca el ícono deslizador para personalizar orientación, tamaño e información de tarjeta de un solo catálogo. Los addons de catálogo de Stremio pueden reducir el rendimiento o tener inconsistencias visuales. Los catálogos de Trakt aparecen después de conectar Trakt."
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activado"
+          }
+        }
+      }
+    },
+    "English, Hindi, Japanese": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English, Hindi, Japanese"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español, Hindi, Japonés"
+          }
+        }
+      }
+    },
+    "Enter a new name for this collection.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new name for this collection."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa un nuevo nombre para esta colección."
+          }
+        }
+      }
+    },
+    "Enter a user-supplied HTTPS repo.json, plugin-list JSON, or .sky package URL. Eclipse does not include or recommend a repository.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a user-supplied HTTPS repo.json, plugin-list JSON, or .sky package URL. Eclipse does not include or recommend a repository."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa una URL HTTPS de repo.json, un JSON de lista de plugins, o un paquete .sky proporcionado por el usuario. Eclipse no incluye ni recomienda ningún repositorio."
           }
         }
       }
@@ -1476,6 +3159,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ingresa un número"
+          }
+        }
+      }
+    },
+    "Enter secure value": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter secure value"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa un valor seguro"
           }
         }
       }
@@ -1531,6 +3231,40 @@
         }
       }
     },
+    "Enter this code": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter this code"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa este código"
+          }
+        }
+      }
+    },
+    "Episodes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episodes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episodios"
+          }
+        }
+      }
+    },
     "Error": {
       "extractionState": "manual",
       "localizations": {
@@ -1544,6 +3278,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Error"
+          }
+        }
+      }
+    },
+    "Exclude All Sources from Auto Mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exclude All Sources from Auto Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir todas las fuentes del modo automático"
           }
         }
       }
@@ -1599,6 +3350,23 @@
         }
       }
     },
+    "Extra Source Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extra Source Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes adicionales de la fuente"
+          }
+        }
+      }
+    },
     "Fetching Streams": {
       "extractionState": "manual",
       "localizations": {
@@ -1612,6 +3380,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Obteniendo transmisiones"
+          }
+        }
+      }
+    },
+    "Filler": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filler"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relleno"
           }
         }
       }
@@ -1633,6 +3418,40 @@
         }
       }
     },
+    "Filters": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filters"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtros"
+          }
+        }
+      }
+    },
+    "Following": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Following"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siguiendo"
+          }
+        }
+      }
+    },
     "Global": {
       "extractionState": "manual",
       "localizations": {
@@ -1650,6 +3469,57 @@
         }
       }
     },
+    "Global follows the Catalogs card info setting. Choose title, year, rating, any combination, or poster only, just for this catalog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global follows the Catalogs card info setting. Choose title, year, rating, any combination, or poster only, just for this catalog."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global sigue el ajuste de información de tarjeta de Catálogos. Elige título, año, calificación, cualquier combinación, o solo carátula, únicamente para este catálogo."
+          }
+        }
+      }
+    },
+    "Global follows the Catalogs orientation. Automatic chooses one orientation per shelf, using posters for anime or missing backdrop artwork.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global follows the Catalogs orientation. Automatic chooses one orientation per shelf, using posters for anime or missing backdrop artwork."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global sigue la orientación de Catálogos. Automático elige una orientación por fila, usando carátulas para anime o cuando falta la imagen de fondo."
+          }
+        }
+      }
+    },
+    "Global follows the Catalogs orientation. Automatic picks poster or landscape per item.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global follows the Catalogs orientation. Automatic picks poster or landscape per item."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global sigue la orientación de Catálogos. Automático elige carátula u horizontal según el elemento."
+          }
+        }
+      }
+    },
     "Global follows the Home Layout orientation. Automatic picks poster or landscape per item.": {
       "extractionState": "manual",
       "localizations": {
@@ -1663,6 +3533,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Global sigue la orientación del Diseño de Inicio. Automático elige póster u horizontal según el elemento."
+          }
+        }
+      }
+    },
+    "Go Back": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go Back"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regresar"
+          }
+        }
+      }
+    },
+    "Got it": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Got it"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entendido"
+          }
+        }
+      }
+    },
+    "HTTPS repository or .sky URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HTTPS repository or .sky URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repositorio HTTPS o URL .sky"
           }
         }
       }
@@ -1748,6 +3669,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ocultar pantalla de bienvenida"
+          }
+        }
+      }
+    },
+    "Hide Streams Without Detected Quality": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Streams Without Detected Quality"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar transmisiones sin calidad detectada"
+          }
+        }
+      }
+    },
+    "Hide Streams Without Language Data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Streams Without Language Data"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar transmisiones sin datos de idioma"
           }
         }
       }
@@ -1905,6 +3860,23 @@
         }
       }
     },
+    "Import a backup or connect a cloud provider to pick up where you left off.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import a backup or connect a cloud provider to pick up where you left off."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa una copia de seguridad o conecta un proveedor de nube para continuar donde lo dejaste."
+          }
+        }
+      }
+    },
     "Import your Watching, Planning, and Completed lists as collections": {
       "extractionState": "manual",
       "localizations": {
@@ -1939,6 +3911,74 @@
         }
       }
     },
+    "Include All Sources in Auto Mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include All Sources in Auto Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluir todas las fuentes en el modo automático"
+          }
+        }
+      }
+    },
+    "Increase": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Increase"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumentar"
+          }
+        }
+      }
+    },
+    "Increase Size": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Increase Size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumentar tamaño"
+          }
+        }
+      }
+    },
+    "Individual Episodes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Individual Episodes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episodios individuales"
+          }
+        }
+      }
+    },
     "Informations Language": {
       "extractionState": "manual",
       "localizations": {
@@ -1952,6 +3992,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Idioma de la información"
+          }
+        }
+      }
+    },
+    "Install": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar"
+          }
+        }
+      }
+    },
+    "Installed plugins remain available. Their pinned repository will be marked unavailable for updates.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed plugins remain available. Their pinned repository will be marked unavailable for updates."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los plugins instalados siguen disponibles. Su repositorio fijado se marcará como no disponible para actualizaciones."
           }
         }
       }
@@ -1990,6 +4064,91 @@
         }
       }
     },
+    "Keep Off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Off"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantener apagado"
+          }
+        }
+      }
+    },
+    "Keep Waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Waiting"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seguir esperando"
+          }
+        }
+      }
+    },
+    "Keep supported preferences such as subtitle appearance, audio language, player behavior, and home layout in sync. Turn this off to give this Apple TV its own settings while your library and progress continue syncing. Installed sources sync separately.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep supported preferences such as subtitle appearance, audio language, player behavior, and home layout in sync. Turn this off to give this Apple TV its own settings while your library and progress continue syncing. Installed sources sync separately."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantiene sincronizadas las preferencias compatibles como apariencia de subtítulos, idioma de audio, comportamiento del reproductor y diseño de inicio. Desactívalo para que este Apple TV tenga sus propios ajustes mientras tu biblioteca y progreso siguen sincronizándose. Las fuentes instaladas se sincronizan por separado."
+          }
+        }
+      }
+    },
+    "Kids profile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kids profile"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perfil infantil"
+          }
+        }
+      }
+    },
+    "Kids profiles hide adult, horror, and other mature titles across home, search, and catalogs.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kids profiles hide adult, horror, and other mature titles across home, search, and catalogs."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los perfiles infantiles ocultan títulos para adultos, de terror y otro contenido maduro en inicio, búsqueda y catálogos."
+          }
+        }
+      }
+    },
     "Language": {
       "extractionState": "manual",
       "localizations": {
@@ -2007,6 +4166,40 @@
         }
       }
     },
+    "Languages to Exclude": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Languages to Exclude"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas a excluir"
+          }
+        }
+      }
+    },
+    "Languages to Include": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Languages to Include"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas a incluir"
+          }
+        }
+      }
+    },
     "Large sync: Eclipse will show progress, honor rate limits, and keep this sheet open until it finishes or you cancel.": {
       "extractionState": "manual",
       "localizations": {
@@ -2020,6 +4213,74 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sincronización grande: Eclipse mostrará el progreso, respetará los límites de solicitudes y mantendrá esta ventana abierta hasta que termine o la canceles."
+          }
+        }
+      }
+    },
+    "Later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Later"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más tarde"
+          }
+        }
+      }
+    },
+    "Layout & Details": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout & Details"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diseño y detalles"
+          }
+        }
+      }
+    },
+    "Leave Session": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leave Session"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir de la sesión"
+          }
+        }
+      }
+    },
+    "Leave Watch Together?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leave Watch Together?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Salir de Ver juntos?"
           }
         }
       }
@@ -2109,6 +4370,23 @@
         }
       }
     },
+    "Loading notification history…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading notification history…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando historial de notificaciones…"
+          }
+        }
+      }
+    },
     "Loading settings...": {
       "extractionState": "manual",
       "localizations": {
@@ -2160,6 +4438,23 @@
         }
       }
     },
+    "Log In": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Log In"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar sesión"
+          }
+        }
+      }
+    },
     "Logger": {
       "extractionState": "manual",
       "localizations": {
@@ -2207,6 +4502,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Más bajo"
+          }
+        }
+      }
+    },
+    "MAL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MAL"
+          }
+        }
+      }
+    },
+    "Manage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administrar"
+          }
+        }
+      }
+    },
+    "Manifest URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manifest URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del manifiesto"
           }
         }
       }
@@ -2364,6 +4710,23 @@
         }
       }
     },
+    "Media state stays on this Apple TV until you turn sync on.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Media state stays on this Apple TV until you turn sync on."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estado multimedia permanece en este Apple TV hasta que actives la sincronización."
+          }
+        }
+      }
+    },
     "Medium": {
       "extractionState": "manual",
       "localizations": {
@@ -2415,6 +4778,40 @@
         }
       }
     },
+    "Move Down": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move Down"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover abajo"
+          }
+        }
+      }
+    },
+    "Move Up": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move Up"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover arriba"
+          }
+        }
+      }
+    },
     "Movies": {
       "extractionState": "manual",
       "localizations": {
@@ -2432,6 +4829,23 @@
         }
       }
     },
+    "Movies & TV Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Movies & TV Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Películas y series"
+          }
+        }
+      }
+    },
     "Multi Gradient": {
       "extractionState": "manual",
       "localizations": {
@@ -2445,6 +4859,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Multidegradado"
+          }
+        }
+      }
+    },
+    "Name it now, or skip and keep the default.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name it now, or skip and keep the default."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponle nombre ahora, o omite y conserva el predeterminado."
+          }
+        }
+      }
+    },
+    "Names and trademarks belong to their respective owners. These acknowledgements do not imply affiliation or endorsement. Each project and service remains subject to its linked license or terms. Eclipse's corresponding source is available from the License & Source page.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Names and trademarks belong to their respective owners. These acknowledgements do not imply affiliation or endorsement. Each project and service remains subject to its linked license or terms. Eclipse's corresponding source is available from the License & Source page."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los nombres y marcas pertenecen a sus respectivos dueños. Estos reconocimientos no implican afiliación ni aprobación. Cada proyecto y servicio sigue sujeto a su licencia o términos correspondientes. El código fuente de Eclipse está disponible en la página de Licencia y código fuente."
           }
         }
       }
@@ -2534,6 +4982,57 @@
         }
       }
     },
+    "No Catalogs Enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Catalogs Enabled"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay catálogos activados"
+          }
+        }
+      }
+    },
+    "No Repositories": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Repositories"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin repositorios"
+          }
+        }
+      }
+    },
+    "No Results": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Results"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin resultados"
+          }
+        }
+      }
+    },
     "No Services": {
       "extractionState": "manual",
       "localizations": {
@@ -2568,6 +5067,40 @@
         }
       }
     },
+    "No Settings Found": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Settings Found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron ajustes"
+          }
+        }
+      }
+    },
+    "No Sources Installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Sources Installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay fuentes instaladas"
+          }
+        }
+      }
+    },
     "No Subtitles": {
       "extractionState": "manual",
       "localizations": {
@@ -2598,6 +5131,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sin entrada de TMDB"
+          }
+        }
+      }
+    },
+    "No aired episodes yet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No aired episodes yet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay episodios emitidos"
+          }
+        }
+      }
+    },
+    "No connected stream sources.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No connected stream sources."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay fuentes de transmisión conectadas."
+          }
+        }
+      }
+    },
+    "No episodes found.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No episodes found."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron episodios."
           }
         }
       }
@@ -2670,6 +5254,23 @@
         }
       }
     },
+    "No providers are ready yet. Retry the failed downloads above.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No providers are ready yet. Retry the failed downloads above."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todavía no hay proveedores listos. Reintenta las descargas fallidas de arriba."
+          }
+        }
+      }
+    },
     "No results found": {
       "extractionState": "manual",
       "localizations": {
@@ -2700,6 +5301,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "No hay servicios ni addons instalados"
+          }
+        }
+      }
+    },
+    "No stream sources installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No stream sources installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay fuentes de transmisión instaladas"
+          }
+        }
+      }
+    },
+    "No streams match your current filters. Go back to Source Results to change them.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No streams match your current filters. Go back to Source Results to change them."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna transmisión coincide con tus filtros actuales. Regresa a Resultados de fuente para cambiarlos."
           }
         }
       }
@@ -2738,6 +5373,40 @@
         }
       }
     },
+    "Not Now": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Now"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ahora no"
+          }
+        }
+      }
+    },
+    "Not available on this profile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not available on this profile"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No disponible en este perfil"
+          }
+        }
+      }
+    },
     "Not searched": {
       "extractionState": "manual",
       "localizations": {
@@ -2751,6 +5420,74 @@
           "stringUnit": {
             "state": "translated",
             "value": "No buscado"
+          }
+        }
+      }
+    },
+    "Notification Center": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notification Center"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro de notificaciones"
+          }
+        }
+      }
+    },
+    "Notifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificaciones"
+          }
+        }
+      }
+    },
+    "Now Playing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Now Playing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduciendo ahora"
+          }
+        }
+      }
+    },
+    "Nuvio Plugins": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuvio Plugins"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plugins de Nuvio"
           }
         }
       }
@@ -2789,6 +5526,74 @@
         }
       }
     },
+    "On your phone or computer, visit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On your phone or computer, visit"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En tu teléfono o computadora, visita"
+          }
+        }
+      }
+    },
+    "Open Release": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Release"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir lanzamiento"
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir ajustes"
+          }
+        }
+      }
+    },
+    "Open on Nearby Device": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open on Nearby Device"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir en dispositivo cercano"
+          }
+        }
+      }
+    },
     "Optional": {
       "extractionState": "manual",
       "localizations": {
@@ -2819,6 +5624,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Orientación"
+          }
+        }
+      }
+    },
+    "Orientation, card size and card info (title, year, rating) moved to Settings > Catalogs, where they can also be customized per catalog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientation, card size and card info (title, year, rating) moved to Settings > Catalogs, where they can also be customized per catalog."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientación, tamaño de tarjeta e información de tarjeta (título, año, calificación) se movieron a Ajustes > Catálogos, donde también se pueden personalizar por catálogo."
+          }
+        }
+      }
+    },
+    "Orientation, size, and card info (title, year, rating) apply to every catalog on the home screen by default. Use the slider icon on a catalog below to override any of these just for that catalog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientation, size, and card info (title, year, rating) apply to every catalog on the home screen by default. Use the slider icon on a catalog below to override any of these just for that catalog."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientación, tamaño e información de tarjeta (título, año, calificación) se aplican a todos los catálogos de la pantalla de inicio por defecto. Usa el ícono deslizador de un catálogo abajo para anular cualquiera de estos solo para ese catálogo."
           }
         }
       }
@@ -2959,6 +5798,23 @@
         }
       }
     },
+    "Player Skin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Player Skin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apariencia del reproductor"
+          }
+        }
+      }
+    },
     "Plugins": {
       "extractionState": "manual",
       "localizations": {
@@ -2972,6 +5828,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Plugins"
+          }
+        }
+      }
+    },
+    "Poster Artwork": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poster Artwork"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imagen de carátula"
+          }
+        }
+      }
+    },
+    "Poster URL Pattern": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poster URL Pattern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Patrón de URL de carátula"
+          }
+        }
+      }
+    },
+    "Preferences": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferences"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferencias"
           }
         }
       }
@@ -3010,6 +5917,142 @@
         }
       }
     },
+    "Prices load from the App Store when these purchases become available.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prices load from the App Store when these purchases become available."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los precios se cargan desde la App Store cuando estas compras estén disponibles."
+          }
+        }
+      }
+    },
+    "Privacy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacidad"
+          }
+        }
+      }
+    },
+    "Private notes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private notes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notas privadas"
+          }
+        }
+      }
+    },
+    "Profile name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del perfil"
+          }
+        }
+      }
+    },
+    "Provider URLs, authorization tokens, cookies, and request headers are intentionally omitted.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provider URLs, authorization tokens, cookies, and request headers are intentionally omitted."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las URLs de proveedor, tokens de autorización, cookies y encabezados de solicitud se omiten intencionalmente."
+          }
+        }
+      }
+    },
+    "Providers from installed repositories appear in Services alongside your other sources.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Providers from installed repositories appear in Services alongside your other sources."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los proveedores de repositorios instalados aparecen en Servicios junto a tus otras fuentes."
+          }
+        }
+      }
+    },
+    "Purchases use the App Store on this Apple TV. External donation and community links are not shown in the TV app.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Purchases use the App Store on this Apple TV. External donation and community links are not shown in the TV app."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las compras usan la App Store en este Apple TV. Los enlaces externos de donación y comunidad no se muestran en la app de TV."
+          }
+        }
+      }
+    },
+    "Qualities to Hide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualities to Hide"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calidades a ocultar"
+          }
+        }
+      }
+    },
     "Quality": {
       "extractionState": "manual",
       "localizations": {
@@ -3040,6 +6083,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Umbral de calidad"
+          }
+        }
+      }
+    },
+    "Random": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Random"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aleatorio"
+          }
+        }
+      }
+    },
+    "Ranking Similarity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ranking Similarity"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Similitud de clasificación"
           }
         }
       }
@@ -3091,6 +6168,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Registros del lector"
+          }
+        }
+      }
+    },
+    "Reading provider settings…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reading provider settings…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leyendo ajustes del proveedor…"
           }
         }
       }
@@ -3163,6 +6257,91 @@
         }
       }
     },
+    "Recovery Not Completed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recovery Not Completed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuperación no completada"
+          }
+        }
+      }
+    },
+    "Refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
+          }
+        }
+      }
+    },
+    "Refresh Repository": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh Repository"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar repositorio"
+          }
+        }
+      }
+    },
+    "Refresh Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar fuentes"
+          }
+        }
+      }
+    },
+    "Rejoin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rejoin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a unirse"
+          }
+        }
+      }
+    },
     "Remove": {
       "extractionState": "manual",
       "localizations": {
@@ -3176,6 +6355,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Quitar"
+          }
+        }
+      }
+    },
+    "Remove All": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar todo"
+          }
+        }
+      }
+    },
+    "Remove All Notification Selections": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove All Notification Selections"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar todas las selecciones de notificación"
           }
         }
       }
@@ -3197,6 +6410,193 @@
         }
       }
     },
+    "Remove Repository": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Repository"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar repositorio"
+          }
+        }
+      }
+    },
+    "Remove Repository?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Repository?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Quitar repositorio?"
+          }
+        }
+      }
+    },
+    "Remove Service?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Service?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Quitar servicio?"
+          }
+        }
+      }
+    },
+    "Remove Stremio Addon?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Stremio Addon?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Quitar addon de Stremio?"
+          }
+        }
+      }
+    },
+    "Removing a repository keeps installed plugins and their settings, but freezes their update provenance.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removing a repository keeps installed plugins and their settings, but freezes their update provenance."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar un repositorio conserva los plugins instalados y sus ajustes, pero congela su procedencia de actualización."
+          }
+        }
+      }
+    },
+    "Rename": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar"
+          }
+        }
+      }
+    },
+    "Rename Collection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Collection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar colección"
+          }
+        }
+      }
+    },
+    "Replace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replace"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reemplazar"
+          }
+        }
+      }
+    },
+    "Replace Cloud Backup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replace Cloud Backup"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reemplazar copia de seguridad en la nube"
+          }
+        }
+      }
+    },
+    "Replace Everywhere": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replace Everywhere"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reemplazar en todos lados"
+          }
+        }
+      }
+    },
+    "Replace poster artwork with images from Better Posters (btttr.cc), a community poster service.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replace poster artwork with images from Better Posters (btttr.cc), a community poster service."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reemplaza la imagen de las carátulas con imágenes de Better Posters (btttr.cc), un servicio comunitario de carátulas."
+          }
+        }
+      }
+    },
     "Repository URL": {
       "extractionState": "manual",
       "localizations": {
@@ -3214,6 +6614,23 @@
         }
       }
     },
+    "Repository unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repository unavailable"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repositorio no disponible"
+          }
+        }
+      }
+    },
     "Requires MoltenVK MPV": {
       "extractionState": "manual",
       "localizations": {
@@ -3227,6 +6644,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Requiere MoltenVK MPV"
+          }
+        }
+      }
+    },
+    "Requires SharePlay. Eclipse can start an invitation, or join an existing FaceTime or Messages group. Participants need access to the same title in Eclipse.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requires SharePlay. Eclipse can start an invitation, or join an existing FaceTime or Messages group. Participants need access to the same title in Eclipse."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requiere SharePlay. Eclipse puede iniciar una invitación, o unirse a un grupo existente de FaceTime o Mensajes. Los participantes necesitan acceso al mismo título en Eclipse."
+          }
+        }
+      }
+    },
+    "Reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer"
           }
         }
       }
@@ -3282,6 +6733,57 @@
         }
       }
     },
+    "Reset Nuvio Plugin Data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Nuvio Plugin Data"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer datos del plugin de Nuvio"
+          }
+        }
+      }
+    },
+    "Reset Plugin Preferences": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Plugin Preferences"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer preferencias del plugin"
+          }
+        }
+      }
+    },
+    "Reset Preferences?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Preferences?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Restablecer preferencias?"
+          }
+        }
+      }
+    },
     "Reset Progress": {
       "extractionState": "manual",
       "localizations": {
@@ -3295,6 +6797,74 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restablecer progreso"
+          }
+        }
+      }
+    },
+    "Reset SkyStream Data?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset SkyStream Data?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Restablecer datos de SkyStream?"
+          }
+        }
+      }
+    },
+    "Reset SkyStream Plugin Data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset SkyStream Plugin Data"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer datos del plugin de SkyStream"
+          }
+        }
+      }
+    },
+    "Reset TV Cache": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset TV Cache"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer caché de TV"
+          }
+        }
+      }
+    },
+    "Reset TV Cache?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset TV Cache?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Restablecer caché de TV?"
           }
         }
       }
@@ -3346,6 +6916,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restablece el tema, el diseño, la experiencia de la app y las anulaciones por catálogo a sus valores predeterminados."
+          }
+        }
+      }
+    },
+    "Resetting clears the saved repositories and installed packages on this device so SkyStream can start over.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetting clears the saved repositories and installed packages on this device so SkyStream can start over."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer borra los repositorios guardados y los paquetes instalados en este dispositivo para que SkyStream empiece de nuevo."
+          }
+        }
+      }
+    },
+    "Restart Eclipse to finish switching the interface language.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart Eclipse to finish switching the interface language."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reinicia Eclipse para terminar de cambiar el idioma de la interfaz."
           }
         }
       }
@@ -3418,6 +7022,40 @@
         }
       }
     },
+    "Restore From Recovery Point": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore From Recovery Point"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar desde el punto de recuperación"
+          }
+        }
+      }
+    },
+    "Restore and Resume Sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore and Resume Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar y reanudar sincronización"
+          }
+        }
+      }
+    },
     "Restore the default order and visibility.": {
       "extractionState": "manual",
       "localizations": {
@@ -3469,6 +7107,23 @@
         }
       }
     },
+    "Results at or above this percentage are prioritized by similarity. When dropping is enabled, search results below this percentage are hidden, Auto Mode skips them instead of using a weaker match, and plugin sources tighten to the same percentage. Percentages under 85% apply to Service sources only, because plugin sources never accept a match below 85%.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Results at or above this percentage are prioritized by similarity. When dropping is enabled, search results below this percentage are hidden, Auto Mode skips them instead of using a weaker match, and plugin sources tighten to the same percentage. Percentages under 85% apply to Service sources only, because plugin sources never accept a match below 85%."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los resultados en o por encima de este porcentaje se priorizan por similitud. Cuando el descarte está activado, los resultados de búsqueda por debajo de este porcentaje se ocultan, el modo automático los omite en lugar de usar una coincidencia más débil, y las fuentes de plugins se ajustan al mismo porcentaje. Los porcentajes menores al 85% aplican solo a fuentes de servicio, porque las fuentes de plugins nunca aceptan una coincidencia menor al 85%."
+          }
+        }
+      }
+    },
     "Resume": {
       "extractionState": "manual",
       "localizations": {
@@ -3499,6 +7154,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reanudar todo"
+          }
+        }
+      }
+    },
+    "Resume Sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar sincronización"
           }
         }
       }
@@ -3622,6 +7294,91 @@
         }
       }
     },
+    "Save Configured URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Configured URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar URL configurado"
+          }
+        }
+      }
+    },
+    "Save Excluded Languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Excluded Languages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar idiomas excluidos"
+          }
+        }
+      }
+    },
+    "Save Included Languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Included Languages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar idiomas incluidos"
+          }
+        }
+      }
+    },
+    "Save to Photos": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save to Photos"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar en Fotos"
+          }
+        }
+      }
+    },
+    "Scan QR": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan QR"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escanear QR"
+          }
+        }
+      }
+    },
     "Schedule": {
       "extractionState": "manual",
       "localizations": {
@@ -3690,6 +7447,23 @@
         }
       }
     },
+    "Search Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar en ajustes"
+          }
+        }
+      }
+    },
     "Searching for:": {
       "extractionState": "manual",
       "localizations": {
@@ -3737,6 +7511,108 @@
           "stringUnit": {
             "state": "translated",
             "value": "Temporadas"
+          }
+        }
+      }
+    },
+    "Secure, synchronized playback through Apple SharePlay.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secure, synchronized playback through Apple SharePlay."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducción segura y sincronizada mediante Apple SharePlay."
+          }
+        }
+      }
+    },
+    "Security Check": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Security Check"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificación de seguridad"
+          }
+        }
+      }
+    },
+    "See All": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver todo"
+          }
+        }
+      }
+    },
+    "See what's airing next": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See what's airing next"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mira qué se transmite después"
+          }
+        }
+      }
+    },
+    "Select Stream": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Stream"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar transmisión"
+          }
+        }
+      }
+    },
+    "Selection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selección"
           }
         }
       }
@@ -3809,6 +7685,57 @@
         }
       }
     },
+    "Settings Sync Is Paused": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings Sync Is Paused"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sincronización de ajustes está en pausa"
+          }
+        }
+      }
+    },
+    "Settings and Reader Mode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings and Reader Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes y modo lector"
+          }
+        }
+      }
+    },
+    "Settings moved somewhere easier to reach. Tap the handle on the edge of the screen.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings moved somewhere easier to reach. Tap the handle on the edge of the screen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los ajustes se movieron a un lugar más fácil de alcanzar. Toca el asa en el borde de la pantalla."
+          }
+        }
+      }
+    },
     "Share": {
       "extractionState": "manual",
       "localizations": {
@@ -3822,6 +7749,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Compartir"
+          }
+        }
+      }
+    },
+    "SharePlay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SharePlay"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SharePlay"
+          }
+        }
+      }
+    },
+    "SharePlay displays the title; sync messages contain only play, pause, seek, and an opaque media identifier.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SharePlay displays the title; sync messages contain only play, pause, seek, and an opaque media identifier."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SharePlay muestra el título; los mensajes de sincronización solo contienen reproducir, pausar, buscar y un identificador de medio opaco."
+          }
+        }
+      }
+    },
+    "SharePlay messages are limited to people in the Apple group session.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SharePlay messages are limited to people in the Apple group session."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los mensajes de SharePlay se limitan a las personas en la sesión de grupo de Apple."
           }
         }
       }
@@ -3856,6 +7834,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Series"
+          }
+        }
+      }
+    },
+    "Shows one compact, filterable list of results and streams instead of grouping them into separate source sections.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows one compact, filterable list of results and streams instead of grouping them into separate source sections."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra una lista compacta y filtrable de resultados y transmisiones en lugar de agruparlos en secciones separadas por fuente."
           }
         }
       }
@@ -3945,6 +7940,40 @@
         }
       }
     },
+    "SkyStream Error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SkyStream Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de SkyStream"
+          }
+        }
+      }
+    },
+    "SkyStream Plugins": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SkyStream Plugins"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plugins de SkyStream"
+          }
+        }
+      }
+    },
     "Solid Color": {
       "extractionState": "manual",
       "localizations": {
@@ -3975,6 +8004,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ordenar"
+          }
+        }
+      }
+    },
+    "Sources": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sources"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuentes"
           }
         }
       }
@@ -4047,6 +8093,40 @@
         }
       }
     },
+    "Stream URLs, request headers, cookies, subtitles, and provider credentials never leave your device.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stream URLs, request headers, cookies, subtitles, and provider credentials never leave your device."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las URLs de transmisión, encabezados de solicitud, cookies, subtítulos y credenciales del proveedor nunca salen de tu dispositivo."
+          }
+        }
+      }
+    },
+    "Stremio Addons": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stremio Addons"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Addons de Stremio"
+          }
+        }
+      }
+    },
     "Stremio Error": {
       "extractionState": "manual",
       "localizations": {
@@ -4060,6 +8140,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Error de Stremio"
+          }
+        }
+      }
+    },
+    "Stremio-Style Stream List": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stremio-Style Stream List"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lista de transmisiones estilo Stremio"
           }
         }
       }
@@ -4115,6 +8212,40 @@
         }
       }
     },
+    "Sync Health": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Health"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado de la sincronización"
+          }
+        }
+      }
+    },
+    "Sync Settings Across Devices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Settings Across Devices"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizar ajustes entre dispositivos"
+          }
+        }
+      }
+    },
     "Sync Tools": {
       "extractionState": "manual",
       "localizations": {
@@ -4128,6 +8259,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Herramientas de sincronización"
+          }
+        }
+      }
+    },
+    "Sync with iCloud": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync with iCloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizar con iCloud"
+          }
+        }
+      }
+    },
+    "Tap the handle on the edge of the screen.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap the handle on the edge of the screen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca el asa en el borde de la pantalla."
           }
         }
       }
@@ -4234,6 +8399,74 @@
         }
       }
     },
+    "This Device Only": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Device Only"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo este dispositivo"
+          }
+        }
+      }
+    },
+    "This changes the package's pinned source, installs an older version, or replaces code without a version change. Existing code stays installed unless the replacement fully validates.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This changes the package's pinned source, installs an older version, or replaces code without a version change. Existing code stays installed unless the replacement fully validates."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto cambia la fuente fijada del paquete, instala una versión anterior, o reemplaza código sin cambio de versión. El código existente permanece instalado a menos que el reemplazo se valide por completo."
+          }
+        }
+      }
+    },
+    "This clears Nuvio repositories, provider settings, repair history, and code owned only by the current Services profile. Other profiles' referenced code is preserved.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This clears Nuvio repositories, provider settings, repair history, and code owned only by the current Services profile. Other profiles' referenced code is preserved."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto borra los repositorios de Nuvio, ajustes de proveedor, historial de reparación y código que pertenece solo al perfil de Servicios actual. El código referenciado por otros perfiles se conserva."
+          }
+        }
+      }
+    },
+    "This device's media state needs recovery. Cloud uploads are paused and incoming sync is held to protect your other devices.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This device's media state needs recovery. Cloud uploads are paused and incoming sync is held to protect your other devices."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estado multimedia de este dispositivo necesita recuperación. Las subidas a la nube están pausadas y la sincronización entrante se retiene para proteger tus otros dispositivos."
+          }
+        }
+      }
+    },
     "This downloaded episode will be permanently removed.": {
       "extractionState": "manual",
       "localizations": {
@@ -4247,6 +8480,91 @@
           "stringUnit": {
             "state": "translated",
             "value": "Este episodio descargado se eliminará permanentemente."
+          }
+        }
+      }
+    },
+    "This is a kids profile, so it can see this plugin but not change or remove it. Switch to a grown-up profile to make those changes.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is a kids profile, so it can see this plugin but not change or remove it. Switch to a grown-up profile to make those changes."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este es un perfil infantil, así que puede ver este plugin pero no cambiarlo ni eliminarlo. Cambia a un perfil de adulto para hacer esos cambios."
+          }
+        }
+      }
+    },
+    "This is a kids profile, so it cannot add, edit, or remove profiles. Switch to a grown-up profile to make those changes.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is a kids profile, so it cannot add, edit, or remove profiles. Switch to a grown-up profile to make those changes."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este es un perfil infantil, así que no puede agregar, editar ni eliminar perfiles. Cambia a un perfil de adulto para hacer esos cambios."
+          }
+        }
+      }
+    },
+    "This package is pinned to a different source, is older, or changed code without a version bump. Existing code remains installed unless the replacement fully validates.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This package is pinned to a different source, is older, or changed code without a version bump. Existing code remains installed unless the replacement fully validates."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este paquete está fijado a otra fuente, es más antiguo, o cambió código sin subir de versión. El código existente permanece instalado a menos que el reemplazo se valide por completo."
+          }
+        }
+      }
+    },
+    "This package runs third-party JavaScript and has not completed Eclipse compatibility testing. Eclipse will still isolate its storage, filter network access, verify package integrity, and reject non-VOD output.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This package runs third-party JavaScript and has not completed Eclipse compatibility testing. Eclipse will still isolate its storage, filter network access, verify package integrity, and reject non-VOD output."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este paquete ejecuta JavaScript de terceros y no ha completado las pruebas de compatibilidad de Eclipse. Aun así, Eclipse aislará su almacenamiento, filtrará el acceso a la red, verificará la integridad del paquete y rechazará resultados que no sean VOD."
+          }
+        }
+      }
+    },
+    "This profile's watch progress, library, and ratings are removed from this device and from your synced accounts. Downloads are shared and stay put.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This profile's watch progress, library, and ratings are removed from this device and from your synced accounts. Downloads are shared and stay put."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El progreso de visualización, biblioteca y calificaciones de este perfil se eliminan de este dispositivo y de tus cuentas sincronizadas. Las descargas son compartidas y permanecen intactas."
           }
         }
       }
@@ -4268,6 +8586,57 @@
         }
       }
     },
+    "This removes every provider in the repository and its downloaded code.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes every provider in the repository and its downloaded code."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto elimina todos los proveedores del repositorio y su código descargado."
+          }
+        }
+      }
+    },
+    "This removes every saved SkyStream repository and installed package from this device. You can add them again afterwards.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes every saved SkyStream repository and installed package from this device. You can add them again afterwards."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto elimina todos los repositorios guardados de SkyStream y los paquetes instalados de este dispositivo. Puedes agregarlos de nuevo después."
+          }
+        }
+      }
+    },
+    "This removes the plugin, every sub-provider row, stored preferences, and its local payload.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes the plugin, every sub-provider row, stored preferences, and its local payload."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto elimina el plugin, todas las filas de subproveedores, las preferencias guardadas y su contenido local."
+          }
+        }
+      }
+    },
     "This service doesn't have configurable settings.": {
       "extractionState": "manual",
       "localizations": {
@@ -4281,6 +8650,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Este servicio no tiene ajustes configurables."
+          }
+        }
+      }
+    },
+    "This third-party package has not completed Eclipse compatibility testing. Install only if you trust its source.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This third-party package has not completed Eclipse compatibility testing. Install only if you trust its source."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este paquete de terceros no ha completado las pruebas de compatibilidad de Eclipse. Instálalo solo si confías en su fuente."
           }
         }
       }
@@ -4455,6 +8841,23 @@
         }
       }
     },
+    "Tips": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tips"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consejos"
+          }
+        }
+      }
+    },
     "Trackers": {
       "extractionState": "manual",
       "localizations": {
@@ -4557,6 +8960,40 @@
         }
       }
     },
+    "Translations are community-contributed and still a work in progress, so some screens may still show English text. Eclipse applies the interface language the next time it launches.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Translations are community-contributed and still a work in progress, so some screens may still show English text. Eclipse applies the interface language the next time it launches."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las traducciones son aportadas por la comunidad y siguen en progreso, así que algunas pantallas pueden seguir mostrando texto en inglés. Eclipse aplica el idioma de la interfaz la próxima vez que se inicie."
+          }
+        }
+      }
+    },
+    "Treat Dubbed Anime Streams as English": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Treat Dubbed Anime Streams as English"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tratar transmisiones de anime dobladas como inglés"
+          }
+        }
+      }
+    },
     "Try Again": {
       "extractionState": "manual",
       "localizations": {
@@ -4570,6 +9007,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Intentar de nuevo"
+          }
+        }
+      }
+    },
+    "Try a setting name, feature, or service.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try a setting name, feature, or service."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intenta con el nombre de un ajuste, función o servicio."
           }
         }
       }
@@ -4608,6 +9062,193 @@
         }
       }
     },
+    "Turn Auto Quality off when you want to choose stream quality yourself. Error Intelligence skips sources that are known to be unavailable.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn Auto Quality off when you want to choose stream quality yourself. Error Intelligence skips sources that are known to be unavailable."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactiva la calidad automática cuando quieras elegir tú mismo la calidad de transmisión. La inteligencia de errores omite fuentes que se sabe que no están disponibles."
+          }
+        }
+      }
+    },
+    "Turn Back On": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn Back On"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a activar"
+          }
+        }
+      }
+    },
+    "Turn On & Join": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn On & Join"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar y unirse"
+          }
+        }
+      }
+    },
+    "UTC": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "UTC"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "UTC"
+          }
+        }
+      }
+    },
+    "Unable to Load": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to Load"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo cargar"
+          }
+        }
+      }
+    },
+    "Uninstall": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar"
+          }
+        }
+      }
+    },
+    "Uninstall Plugin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall Plugin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar plugin"
+          }
+        }
+      }
+    },
+    "Uninstall Plugin?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstall Plugin?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Desinstalar plugin?"
+          }
+        }
+      }
+    },
+    "Uninstalling removes the whole package and all of its provider rows.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uninstalling removes the whole package and all of its provider rows."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desinstalar elimina todo el paquete y todas sus filas de proveedor."
+          }
+        }
+      }
+    },
+    "Untested Plugin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untested Plugin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plugin sin probar"
+          }
+        }
+      }
+    },
+    "Update Available": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Available"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización disponible"
+          }
+        }
+      }
+    },
     "Update URL": {
       "extractionState": "manual",
       "localizations": {
@@ -4621,6 +9262,159 @@
           "stringUnit": {
             "state": "translated",
             "value": "Actualizar URL"
+          }
+        }
+      }
+    },
+    "Update provenance is frozen": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update provenance is frozen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La procedencia de la actualización está congelada"
+          }
+        }
+      }
+    },
+    "Updating results": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updating results"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando resultados"
+          }
+        }
+      }
+    },
+    "Use My Other Devices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use My Other Devices"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar mis otros dispositivos"
+          }
+        }
+      }
+    },
+    "Use My Other Devices applies the settings already shared across your account. Use This Apple TV shares this device's current settings with your other devices. Settings sync stays off until you choose.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use My Other Devices applies the settings already shared across your account. Use This Apple TV shares this device's current settings with your other devices. Settings sync stays off until you choose."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"Usar mis otros dispositivos\" aplica los ajustes ya compartidos en tu cuenta. \"Usar este Apple TV\" comparte los ajustes actuales de este dispositivo con tus otros dispositivos. La sincronización de ajustes permanece apagada hasta que elijas."
+          }
+        }
+      }
+    },
+    "Use This Apple TV": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use This Apple TV"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar este Apple TV"
+          }
+        }
+      }
+    },
+    "Use This Device": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use This Device"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar este dispositivo"
+          }
+        }
+      }
+    },
+    "Use the arrow buttons to change section order. Hidden rows will not appear on media detail pages.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the arrow buttons to change section order. Hidden rows will not appear on media detail pages."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa los botones de flecha para cambiar el orden de las secciones. Las filas ocultas no aparecerán en las páginas de detalle."
+          }
+        }
+      }
+    },
+    "Verified VOD": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verified VOD"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VOD verificado"
+          }
+        }
+      }
+    },
+    "Verify Cloudflare": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verify Cloudflare"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar Cloudflare"
           }
         }
       }
@@ -4642,6 +9436,40 @@
         }
       }
     },
+    "Waiting for the Host": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for the Host"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperando al anfitrión"
+          }
+        }
+      }
+    },
+    "Waiting for you to approve sign-in…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for you to approve sign-in…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperando a que apruebes el inicio de sesión…"
+          }
+        }
+      }
+    },
     "Watch Now": {
       "extractionState": "manual",
       "localizations": {
@@ -4655,6 +9483,125 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ver ahora"
+          }
+        }
+      }
+    },
+    "Watch Together": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Watch Together"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver juntos"
+          }
+        }
+      }
+    },
+    "Watch Together is Off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Watch Together is Off"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver juntos está apagado"
+          }
+        }
+      }
+    },
+    "Watched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visto"
+          }
+        }
+      }
+    },
+    "Welcome back": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome back"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bienvenido de nuevo"
+          }
+        }
+      }
+    },
+    "Which Settings Should Win?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Which Settings Should Win?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Qué ajustes deben prevalecer?"
+          }
+        }
+      }
+    },
+    "Which profile is yours?": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Which profile is yours?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Cuál perfil es el tuyo?"
+          }
+        }
+      }
+    },
+    "You closed the shared title while SharePlay is still active. Leaving stops syncing with the group on this device.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You closed the shared title while SharePlay is still active. Leaving stops syncing with the group on this device."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerraste el título compartido mientras SharePlay sigue activo. Salir detiene la sincronización con el grupo en este dispositivo."
           }
         }
       }
@@ -4693,6 +9640,108 @@
         }
       }
     },
+    "You don't have any active sources. Open Services settings to add or enable one.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You don't have any active sources. Open Services settings to add or enable one."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tienes fuentes activas. Abre los ajustes de Servicios para agregar o activar una."
+          }
+        }
+      }
+    },
+    "You joined the Watch Together session, but the host's Eclipse hasn't responded yet. Ask them to open Eclipse with their video playing.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You joined the Watch Together session, but the host's Eclipse hasn't responded yet. Ask them to open Eclipse with their video playing."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Te uniste a la sesión de Ver juntos, pero el Eclipse del anfitrión aún no ha respondido. Pídele que abra Eclipse con su video reproduciéndose."
+          }
+        }
+      }
+    },
+    "Your Other Devices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Other Devices"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus otros dispositivos"
+          }
+        }
+      }
+    },
+    "Your name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your name"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu nombre"
+          }
+        }
+      }
+    },
+    "Your profiles came back with your data. Pick the one to open Eclipse with.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your profiles came back with your data. Pick the one to open Eclipse with."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus perfiles regresaron con tus datos. Elige con cuál abrir Eclipse."
+          }
+        }
+      }
+    },
+    "Your settings may have changed on this device while syncing was off. \"Use My Other Devices\" replaces this device's settings with the ones already shared across your account. \"Use This Device\" makes these settings the shared ones and updates your other devices. Settings sync stays off until you choose.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your settings may have changed on this device while syncing was off. \"Use My Other Devices\" replaces this device's settings with the ones already shared across your account. \"Use This Device\" makes these settings the shared ones and updates your other devices. Settings sync stays off until you choose."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tus ajustes pueden haber cambiado en este dispositivo mientras la sincronización estaba apagada. \\\"Usar mis otros dispositivos\\\" reemplaza los ajustes de este dispositivo con los ya compartidos en tu cuenta. \\\"Usar este dispositivo\\\" hace que estos ajustes sean los compartidos y actualiza tus otros dispositivos. La sincronización de ajustes permanece apagada hasta que elijas."
+          }
+        }
+      }
+    },
     "iCloud Sync": {
       "extractionState": "manual",
       "localizations": {
@@ -4706,6 +9755,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sincronización con iCloud"
+          }
+        }
+      }
+    },
+    "· Custom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· Custom"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· Personalizado"
           }
         }
       }

--- a/Eclipse/Localizable.xcstrings
+++ b/Eclipse/Localizable.xcstrings
@@ -307,6 +307,23 @@
         }
       }
     },
+    "Airing Today TV Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Airing Today TV Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Series que se estrenan hoy"
+          }
+        }
+      }
+    },
     "Already use Eclipse?": {
       "extractionState": "manual",
       "localizations": {
@@ -936,6 +953,23 @@
         }
       }
     },
+    "Because You Watched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Because You Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Porque viste"
+          }
+        }
+      }
+    },
     "Behavior": {
       "extractionState": "manual",
       "localizations": {
@@ -949,6 +983,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Comportamiento"
+          }
+        }
+      }
+    },
+    "Best Anime": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Best Anime"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mejor anime"
+          }
+        }
+      }
+    },
+    "Best Movies": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Best Movies"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mejores películas"
+          }
+        }
+      }
+    },
+    "Best TV Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Best TV Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mejores series"
           }
         }
       }
@@ -1187,6 +1272,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Los cambios están bloqueados"
+          }
+        }
+      }
+    },
+    "Channels": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channels"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canales"
           }
         }
       }
@@ -1713,7 +1815,7 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Empresa"
+            "value": "Compañía"
           }
         }
       }
@@ -1922,6 +2024,23 @@
         }
       }
     },
+    "Continue Watching": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue Watching"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seguir viendo"
+          }
+        }
+      }
+    },
     "Copy Log Message": {
       "extractionState": "manual",
       "localizations": {
@@ -2105,6 +2224,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Color actual"
+          }
+        }
+      }
+    },
+    "Currently Airing Anime": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currently Airing Anime"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anime en emisión"
           }
         }
       }
@@ -2530,6 +2666,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Listo"
+          }
+        }
+      }
+    },
+    "Double tap to play automatically. Touch and hold to choose a source manually.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Double tap to play automatically. Touch and hold to choose a source manually."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca dos veces para reproducir automáticamente. Mantén presionado para elegir una fuente manualmente."
           }
         }
       }
@@ -3367,6 +3520,23 @@
         }
       }
     },
+    "Featured": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Featured"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destacado"
+          }
+        }
+      }
+    },
     "Fetching Streams": {
       "extractionState": "manual",
       "localizations": {
@@ -4060,6 +4230,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "URL de JSON"
+          }
+        }
+      }
+    },
+    "Just For You": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Just For You"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para ti"
           }
         }
       }
@@ -5475,6 +5662,23 @@
         }
       }
     },
+    "Now Playing Movies": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Now Playing Movies"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Películas en cartelera"
+          }
+        }
+      }
+    },
     "Nuvio Plugins": {
       "extractionState": "manual",
       "localizations": {
@@ -5522,6 +5726,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Desactivado sigue el tamaño global. Las filas de widgets solo admiten tamaño."
+          }
+        }
+      }
+    },
+    "On The Air TV Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On The Air TV Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Series al aire"
           }
         }
       }
@@ -5828,6 +6049,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Plugins"
+          }
+        }
+      }
+    },
+    "Popular Anime": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Popular Anime"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anime popular"
+          }
+        }
+      }
+    },
+    "Popular Movies": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Popular Movies"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Películas populares"
+          }
+        }
+      }
+    },
+    "Popular TV Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Popular TV Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Series populares"
           }
         }
       }
@@ -8161,6 +8433,23 @@
         }
       }
     },
+    "Studio": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Studio"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estudio"
+          }
+        }
+      }
+    },
     "Support": {
       "extractionState": "manual",
       "localizations": {
@@ -8858,6 +9147,57 @@
         }
       }
     },
+    "Top Rated Anime": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Top Rated Anime"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anime mejor calificado"
+          }
+        }
+      }
+    },
+    "Top Rated Movies": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Top Rated Movies"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Películas mejor calificadas"
+          }
+        }
+      }
+    },
+    "Top Rated TV Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Top Rated TV Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Series mejor calificadas"
+          }
+        }
+      }
+    },
     "Trackers": {
       "extractionState": "manual",
       "localizations": {
@@ -8990,6 +9330,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tratar transmisiones de anime dobladas como inglés"
+          }
+        }
+      }
+    },
+    "Trending Anime": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trending Anime"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anime en tendencia"
+          }
+        }
+      }
+    },
+    "Trending This Week": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trending This Week"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendencias de esta semana"
           }
         }
       }
@@ -9228,6 +9602,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Plugin sin probar"
+          }
+        }
+      }
+    },
+    "Upcoming Anime": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upcoming Anime"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próximos animes"
+          }
+        }
+      }
+    },
+    "Upcoming Movies": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upcoming Movies"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próximas películas"
+          }
+        }
+      }
+    },
+    "Upcoming TV Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upcoming TV Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próximas series"
           }
         }
       }

--- a/Eclipse/Localizable.xcstrings
+++ b/Eclipse/Localizable.xcstrings
@@ -1815,7 +1815,7 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Empresa"
+            "value": "Compañía"
           }
         }
       }
@@ -6714,7 +6714,8 @@
             "value": "¿Quitar repositorio?"
           }
         }
-      }
+      },
+      "shouldGenerateStringsSymbol": false
     },
     "Remove Service?": {
       "extractionState": "manual",
@@ -7139,7 +7140,8 @@
             "value": "¿Restablecer caché de TV?"
           }
         }
-      }
+      },
+      "shouldGenerateStringsSymbol": false
     },
     "Reset to Global": {
       "extractionState": "manual",
@@ -9570,7 +9572,8 @@
             "value": "¿Desinstalar plugin?"
           }
         }
-      }
+      },
+      "shouldGenerateStringsSymbol": false
     },
     "Uninstalling removes the whole package and all of its provider rows.": {
       "extractionState": "manual",
@@ -9961,7 +9964,8 @@
             "value": "Visto"
           }
         }
-      }
+      },
+      "shouldGenerateStringsSymbol": false
     },
     "Welcome back": {
       "extractionState": "manual",

--- a/Eclipse/Models/BetterPostersSettings.swift
+++ b/Eclipse/Models/BetterPostersSettings.swift
@@ -1,0 +1,70 @@
+
+import Foundation
+
+enum BetterPostersSettings {
+    static let enabledKey = "betterPostersEnabled"
+    static let urlPatternKey = "betterPostersURLPattern"
+    static let applyToHomeKey = "betterPostersApplyToHome"
+
+    static let defaultEnabled = false
+    static let defaultApplyToHome = false
+
+    static let placeholderToken = "{imdb_id}"
+
+    static var isEnabled: Bool {
+        let defaults = ProfileSettingsStore.active
+        return defaults.object(forKey: enabledKey) == nil ? defaultEnabled : defaults.bool(forKey: enabledKey)
+    }
+
+    static var applyToHomeScreen: Bool {
+        let defaults = ProfileSettingsStore.active
+        return defaults.object(forKey: applyToHomeKey) == nil ? defaultApplyToHome : defaults.bool(forKey: applyToHomeKey)
+    }
+
+    static var urlPattern: String? {
+        let pattern = ProfileSettingsStore.active.string(forKey: urlPatternKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (pattern?.isEmpty ?? true) ? nil : pattern
+    }
+
+    static func posterURL(imdbId: String?) -> String? {
+        guard isEnabled, let pattern = urlPattern, let imdbId, !imdbId.isEmpty else { return nil }
+        guard pattern.contains(placeholderToken) else { return nil }
+        return pattern.replacingOccurrences(of: placeholderToken, with: imdbId)
+    }
+}
+
+actor IMDbIDCache {
+    static let shared = IMDbIDCache()
+
+    private var cache: [String: String] = [:]
+    private var inFlight: [String: Task<String?, Never>] = [:]
+
+    private func key(tmdbId: Int, isMovie: Bool) -> String {
+        "\(isMovie ? "movie" : "tv")-\(tmdbId)"
+    }
+
+    func imdbId(tmdbId: Int, isMovie: Bool, tmdbService: TMDBService) async -> String? {
+        let cacheKey = key(tmdbId: tmdbId, isMovie: isMovie)
+
+        if let cached = cache[cacheKey] {
+            return cached
+        }
+
+        if let existingTask = inFlight[cacheKey] {
+            return await existingTask.value
+        }
+
+        let task = Task<String?, Never> {
+            await tmdbService.fetchExternalImdbId(tmdbId: tmdbId, isMovie: isMovie)
+        }
+        inFlight[cacheKey] = task
+
+        let result = await task.value
+        inFlight[cacheKey] = nil
+        if let result {
+            cache[cacheKey] = result
+        }
+        return result
+    }
+}

--- a/Eclipse/Models/CatalogManager.swift
+++ b/Eclipse/Models/CatalogManager.swift
@@ -192,7 +192,7 @@ class CatalogManager: ObservableObject {
             Catalog(id: "becauseYouWatched", name: "Because You Watched", source: .local, isEnabled: true, order: 1),
             Catalog(id: "trending", name: "Trending This Week", source: .tmdb, isEnabled: true, order: 2),
             Catalog(id: "popularMovies", name: "Popular Movies", source: .tmdb, isEnabled: true, order: 3),
-            Catalog(id: "networks", name: "Network", source: .tmdb, isEnabled: true, order: 4, displayStyle: .network),
+            Catalog(id: "networks", name: "TV Networks", source: .tmdb, isEnabled: true, order: 4, displayStyle: .network),
             Catalog(id: "nowPlayingMovies", name: "Now Playing Movies", source: .tmdb, isEnabled: false, order: 5),
             Catalog(id: "upcomingMovies", name: "Upcoming Movies", source: .tmdb, isEnabled: false, order: 6),
             Catalog(id: "upcomingTV", name: "Upcoming TV Shows", source: .tmdb, isEnabled: false, order: 7),

--- a/Eclipse/Models/HomeCatalogLayout.swift
+++ b/Eclipse/Models/HomeCatalogLayout.swift
@@ -41,7 +41,9 @@ struct CatalogLayoutOverride: Codable, Equatable {
 
     var sizeScale: Double? = nil
 
-    var isEmpty: Bool { orientation == .global && sizeScale == nil }
+    var cardInfoDisplay: HomeCardInfoDisplay? = nil
+
+    var isEmpty: Bool { orientation == .global && sizeScale == nil && cardInfoDisplay == nil }
 
     static let empty = CatalogLayoutOverride()
 }
@@ -87,6 +89,12 @@ final class HomeCatalogLayoutStore: ObservableObject {
         } else {
             value.sizeScale = nil
         }
+        store(value, for: id)
+    }
+
+    func setCardInfoDisplay(_ display: HomeCardInfoDisplay?, for id: String) {
+        var value = override(for: id)
+        value.cardInfoDisplay = display
         store(value, for: id)
     }
 

--- a/Eclipse/TMDB/TMDBService.swift
+++ b/Eclipse/TMDB/TMDBService.swift
@@ -478,6 +478,26 @@ class TMDBService: ObservableObject {
         }
     }
 
+    func fetchExternalImdbId(tmdbId: Int, isMovie: Bool) async -> String? {
+        guard RemoteMediaNumericBoundary.positiveIdentifier(tmdbId) != nil else { return nil }
+        let path = isMovie ? "movie" : "tv"
+        let urlString = "\(baseURL)/\(path)/\(tmdbId)/external_ids?api_key=\(apiKey)"
+        guard let url = URL(string: urlString) else { return nil }
+
+        struct ExternalIdsResponse: Decodable {
+            let imdb_id: String?
+        }
+
+        do {
+            let (data, _) = try await throttledData(from: url)
+            let decoded = try JSONDecoder().decode(ExternalIdsResponse.self, from: data)
+            let imdbId = decoded.imdb_id
+            return (imdbId?.isEmpty ?? true) ? nil : imdbId
+        } catch {
+            return nil
+        }
+    }
+
     func getTVShowWithSeasons(id: Int) async throws -> TMDBTVShowWithSeasons {
         guard RemoteMediaNumericBoundary.positiveIdentifier(id) != nil else {
             throw TMDBError.invalidURL

--- a/Eclipse/Views/HomeView.swift
+++ b/Eclipse/Views/HomeView.swift
@@ -131,13 +131,26 @@ private func homeTMDBRatingText(_ voteAverage: Double?) -> String? {
 
 private struct HomeCardSubtitle: View {
     let result: TMDBSearchResult
+    var catalogId: String? = nil
+
+    @AppStorage(HomeCardInfoDisplay.storageKey) private var globalCardInfoDisplayRaw = HomeCardInfoDisplay.defaultValue.rawValue
+    @ObservedObject private var layoutStore = HomeCatalogLayoutStore.shared
+
+    private var cardInfoDisplay: HomeCardInfoDisplay {
+        if let catalogId, let override = layoutStore.override(for: catalogId).cardInfoDisplay {
+            return override
+        }
+        return HomeCardInfoDisplay(rawValue: globalCardInfoDisplayRaw) ?? .defaultValue
+    }
 
     private var year: String? {
-        result.displayDate.isEmpty ? nil : String(result.displayDate.prefix(4))
+        guard cardInfoDisplay.showsYear else { return nil }
+        return result.displayDate.isEmpty ? nil : String(result.displayDate.prefix(4))
     }
 
     private var rating: String? {
-        homeTMDBRatingText(result.voteAverage)
+        guard cardInfoDisplay.showsRating else { return nil }
+        return homeTMDBRatingText(result.voteAverage)
     }
 
     var body: some View {
@@ -1669,7 +1682,8 @@ struct HomeView: View {
                                 title: displayTitle,
                                 initialItems: detailItems
                             ),
-                            metrics: catalogMetrics
+                            metrics: catalogMetrics,
+                            catalogId: catalog.id
                         )
                     }
 
@@ -2720,6 +2734,7 @@ struct MediaSection: View {
     let items: [TMDBSearchResult]
     var destination: DiscoverDetailView?
     var metrics: ExperimentalMediaDesignMetrics = .current
+    var catalogId: String? = nil
 
     var gap: Double { isTvOS ? 50.0 : (isIPad ? 28.0 : 20.0) }
 
@@ -2738,7 +2753,8 @@ struct MediaSection: View {
                 items: items,
                 destination: destination,
                 preferredStyle: title.localizedCaseInsensitiveContains("anime") ? .poster : .automatic,
-                metrics: metrics
+                metrics: metrics,
+                catalogId: catalogId
             )
         } else {
             legacySection
@@ -2775,7 +2791,8 @@ struct MediaSection: View {
                             result: item,
                             heroID: "home-\(title)-\(index)-\(item.stableIdentity)",
                             metrics: metrics,
-                            preferredStyle: shelfStyle
+                            preferredStyle: shelfStyle,
+                            catalogId: catalogId
                         )
                     }
 #if os(tvOS)
@@ -2887,6 +2904,7 @@ struct ExperimentalMediaShelf: View {
     var destination: DiscoverDetailView?
     let preferredStyle: ExperimentalMediaShelfStyle
     let metrics: ExperimentalMediaDesignMetrics
+    var catalogId: String? = nil
 
     private var gap: CGFloat { isIPad ? 22 : 20 }
     private var resolvedStyle: ExperimentalMediaShelfStyle {
@@ -2928,7 +2946,8 @@ struct ExperimentalMediaShelf: View {
                             result: item,
                             heroID: "experimental-home-\(title)-\(index)-\(item.stableIdentity)",
                             preferredStyle: shelfStyle,
-                            metrics: metrics
+                            metrics: metrics,
+                            catalogId: catalogId
                         )
                     }
                 }
@@ -2947,8 +2966,19 @@ struct ExperimentalMediaCard: View {
     let heroID: String
     let preferredStyle: ExperimentalMediaShelfStyle
     let metrics: ExperimentalMediaDesignMetrics
+    var catalogId: String? = nil
 
     @Environment(\.heroNamespace) private var heroNamespace
+    @AppStorage(HomeCardInfoDisplay.storageKey) private var globalCardInfoDisplayRaw = HomeCardInfoDisplay.defaultValue.rawValue
+    @ObservedObject private var layoutStore = HomeCatalogLayoutStore.shared
+    @State private var betterPosterURL: String? = nil
+
+    private var cardInfoDisplay: HomeCardInfoDisplay {
+        if let catalogId, let override = layoutStore.override(for: catalogId).cardInfoDisplay {
+            return override
+        }
+        return HomeCardInfoDisplay(rawValue: globalCardInfoDisplayRaw) ?? .defaultValue
+    }
 
     private var resolvedStyle: ExperimentalMediaShelfStyle {
         switch preferredStyle {
@@ -2984,8 +3014,16 @@ struct ExperimentalMediaCard: View {
         case .landscape, .automatic:
             return result.fullBackdropURL ?? result.fullPosterURL ?? ""
         case .poster:
-            return result.fullPosterURL ?? result.fullBackdropURL ?? ""
+            return betterPosterURL ?? result.fullPosterURL ?? result.fullBackdropURL ?? ""
         }
+    }
+
+    private func resolveBetterPosterIfNeeded() async {
+        guard resolvedStyle == .poster,
+              BetterPostersSettings.isEnabled,
+              BetterPostersSettings.applyToHomeScreen else { return }
+        let imdbId = await IMDbIDCache.shared.imdbId(tmdbId: result.id, isMovie: result.isMovie, tmdbService: .shared)
+        betterPosterURL = BetterPostersSettings.posterURL(imdbId: imdbId)
     }
 
     var body: some View {
@@ -2995,23 +3033,32 @@ struct ExperimentalMediaCard: View {
             VStack(alignment: .leading, spacing: 8) {
                 mediaImage
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(result.displayTitle)
-                        .font(.system(size: resolvedStyle == .poster ? (isIPad ? 19 : 17) : (isIPad ? 21 : 20), weight: .medium))
-                        .foregroundColor(.white)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.82)
+                if cardInfoDisplay.showsAnyText {
+                    VStack(alignment: .leading, spacing: 2) {
+                        if cardInfoDisplay.showsTitle {
+                            Text(result.displayTitle)
+                                .font(.system(size: resolvedStyle == .poster ? (isIPad ? 19 : 17) : (isIPad ? 21 : 20), weight: .medium))
+                                .foregroundColor(.white)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.82)
+                        }
 
-                    HomeCardSubtitle(result: result)
-                        .font(.system(size: isIPad ? 16 : 15, weight: .regular))
-                        .foregroundColor(.white.opacity(0.56))
-                        .lineLimit(1)
+                        if cardInfoDisplay.showsYear || cardInfoDisplay.showsRating {
+                            HomeCardSubtitle(result: result, catalogId: catalogId)
+                                .font(.system(size: isIPad ? 16 : 15, weight: .regular))
+                                .foregroundColor(.white.opacity(0.56))
+                                .lineLimit(1)
+                        }
+                    }
+                    .frame(width: cardSize.width, alignment: .leading)
                 }
-                .frame(width: cardSize.width, alignment: .leading)
             }
             .frame(width: cardSize.width, alignment: .leading)
         }
         .buttonStyle(PlainButtonStyle())
+        .task(id: result.id) {
+            await resolveBetterPosterIfNeeded()
+        }
     }
 
     private var mediaImage: some View {
@@ -3078,7 +3125,18 @@ struct MediaCard: View {
     let heroID: String
     var metrics: ExperimentalMediaDesignMetrics = .current
     var preferredStyle: ExperimentalMediaShelfStyle = .poster
+    var catalogId: String? = nil
     @Environment(\.heroNamespace) private var heroNamespace
+    @AppStorage(HomeCardInfoDisplay.storageKey) private var globalCardInfoDisplayRaw = HomeCardInfoDisplay.defaultValue.rawValue
+    @ObservedObject private var layoutStore = HomeCatalogLayoutStore.shared
+    @State private var betterPosterURL: String? = nil
+
+    private var cardInfoDisplay: HomeCardInfoDisplay {
+        if let catalogId, let override = layoutStore.override(for: catalogId).cardInfoDisplay {
+            return override
+        }
+        return HomeCardInfoDisplay(rawValue: globalCardInfoDisplayRaw) ?? .defaultValue
+    }
 
     private var posterWidth: CGFloat { isTvOS ? 280 * metrics.mediaCardScale : 120 * iPadScale }
     private var posterHeight: CGFloat { isTvOS ? 380 * metrics.mediaCardScale : 180 * iPadScale }
@@ -3110,11 +3168,22 @@ struct MediaCard: View {
 #else
         .buttonStyle(PlainButtonStyle())
 #endif
+        .task(id: result.id) {
+            await resolveBetterPosterIfNeeded()
+        }
+    }
+
+    private func resolveBetterPosterIfNeeded() async {
+        guard !usesBackdropCard,
+              BetterPostersSettings.isEnabled,
+              BetterPostersSettings.applyToHomeScreen else { return }
+        let imdbId = await IMDbIDCache.shared.imdbId(tmdbId: result.id, isMovie: result.isMovie, tmdbService: .shared)
+        betterPosterURL = BetterPostersSettings.posterURL(imdbId: imdbId)
     }
 
     private var posterCard: some View {
         VStack(alignment: .leading, spacing: 6) {
-            KFImage(URL(string: result.fullPosterURL ?? ""))
+            KFImage(URL(string: betterPosterURL ?? result.fullPosterURL ?? ""))
                 .setProcessor(DownsamplingImageProcessor(size: homeImageDecodeSize(width: posterWidth, height: posterHeight)))
                 .placeholder {
                     FallbackImageView(
@@ -3136,51 +3205,57 @@ struct MediaCard: View {
                 })
                 .heroSource(id: heroID, namespace: heroNamespace)
 
-            VStack(alignment: .leading, spacing: isTvOS ? 10 : 3) {
-                Text(result.displayTitle)
-                    .tvos({ view in
-                        view
-                            .foregroundColor(.white.opacity(0.88))
-                            .font(.system(size: 27, weight: .semibold))
-                    }, else: { view in
-                        view
-                            .foregroundColor(.white)
-                            .fontWeight(.medium)
-                            .font(.caption)
-                    })
-                    .lineLimit(1)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: .infinity, alignment: .center)
-
-                HStack(alignment: .center, spacing: isTvOS ? 18 : 8) {
-                    HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        Image(systemName: "star.fill")
-                            .font(.caption2)
-                            .foregroundColor(.yellow)
-
-                        Text(String(format: "%.1f", result.voteAverage ?? 0.0))
-                            .font(.caption2)
-                            .foregroundColor(.white)
+            if cardInfoDisplay.showsAnyText {
+                VStack(alignment: .leading, spacing: isTvOS ? 10 : 3) {
+                    if cardInfoDisplay.showsTitle {
+                        Text(result.displayTitle)
+                            .tvos({ view in
+                                view
+                                    .foregroundColor(.white.opacity(0.88))
+                                    .font(.system(size: 27, weight: .semibold))
+                            }, else: { view in
+                                view
+                                    .foregroundColor(.white)
+                                    .fontWeight(.medium)
+                                    .font(.caption)
+                            })
                             .lineLimit(1)
-                            .fixedSize()
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: .infinity, alignment: .center)
                     }
-                    .padding(.horizontal, isTvOS ? 16 : 8)
-                    .padding(.vertical, isTvOS ? 10 : 4)
-                    .applyLiquidGlassBackground(cornerRadius: 12)
 
-                    Spacer()
+                    if cardInfoDisplay.showsRating {
+                        HStack(alignment: .center, spacing: isTvOS ? 18 : 8) {
+                            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                                Image(systemName: "star.fill")
+                                    .font(.caption2)
+                                    .foregroundColor(.yellow)
 
-                    Text(result.isMovie ? "Movie" : "TV")
-                        .font(.caption2)
-                        .foregroundColor(.white)
-                        .lineLimit(1)
-                        .fixedSize()
-                        .padding(.horizontal, isTvOS ? 16 : 8)
-                        .padding(.vertical, isTvOS ? 10 : 4)
-                        .applyLiquidGlassBackground(cornerRadius: 12)
+                                Text(String(format: "%.1f", result.voteAverage ?? 0.0))
+                                    .font(.caption2)
+                                    .foregroundColor(.white)
+                                    .lineLimit(1)
+                                    .fixedSize()
+                            }
+                            .padding(.horizontal, isTvOS ? 16 : 8)
+                            .padding(.vertical, isTvOS ? 10 : 4)
+                            .applyLiquidGlassBackground(cornerRadius: 12)
+
+                            Spacer()
+
+                            Text(result.isMovie ? "Movie" : "TV")
+                                .font(.caption2)
+                                .foregroundColor(.white)
+                                .lineLimit(1)
+                                .fixedSize()
+                                .padding(.horizontal, isTvOS ? 16 : 8)
+                                .padding(.vertical, isTvOS ? 10 : 4)
+                                .applyLiquidGlassBackground(cornerRadius: 12)
+                        }
+                    }
                 }
+                .frame(width: posterWidth, alignment: .leading)
             }
-            .frame(width: posterWidth, alignment: .leading)
         }
     }
 
@@ -3205,18 +3280,24 @@ struct MediaCard: View {
                 .shadow(color: .black.opacity(0.22), radius: 10, x: 0, y: 5)
                 .heroSource(id: heroID, namespace: heroNamespace)
 
-            VStack(alignment: .leading, spacing: isTvOS ? 8 : 2) {
-                Text(result.displayTitle)
-                    .font(.system(size: isTvOS ? 27 : (isIPad ? 19 : 18), weight: isTvOS ? .semibold : .medium))
-                    .foregroundColor(.white)
-                    .lineLimit(1)
-                    .frame(width: backdropWidth, alignment: .leading)
+            if cardInfoDisplay.showsAnyText {
+                VStack(alignment: .leading, spacing: isTvOS ? 8 : 2) {
+                    if cardInfoDisplay.showsTitle {
+                        Text(result.displayTitle)
+                            .font(.system(size: isTvOS ? 27 : (isIPad ? 19 : 18), weight: isTvOS ? .semibold : .medium))
+                            .foregroundColor(.white)
+                            .lineLimit(1)
+                            .frame(width: backdropWidth, alignment: .leading)
+                    }
 
-                HomeCardSubtitle(result: result)
-                    .font(.system(size: isTvOS ? 23 : (isIPad ? 15 : 14), weight: .regular))
-                    .foregroundColor(.white.opacity(0.58))
-                    .lineLimit(1)
-                    .frame(width: backdropWidth, alignment: .leading)
+                    if cardInfoDisplay.showsYear || cardInfoDisplay.showsRating {
+                        HomeCardSubtitle(result: result, catalogId: catalogId)
+                            .font(.system(size: isTvOS ? 23 : (isIPad ? 15 : 14), weight: .regular))
+                            .foregroundColor(.white.opacity(0.58))
+                            .lineLimit(1)
+                            .frame(width: backdropWidth, alignment: .leading)
+                    }
+                }
             }
         }
         .frame(width: backdropWidth, alignment: .leading)

--- a/Eclipse/Views/HomeView.swift
+++ b/Eclipse/Views/HomeView.swift
@@ -3018,10 +3018,17 @@ struct ExperimentalMediaCard: View {
         }
     }
 
+    private var betterPosterTaskKey: String {
+        "\(result.id)-\(BetterPostersSettings.isEnabled)-\(BetterPostersSettings.applyToHomeScreen)-\(BetterPostersSettings.urlPattern ?? "")"
+    }
+
     private func resolveBetterPosterIfNeeded() async {
         guard resolvedStyle == .poster,
               BetterPostersSettings.isEnabled,
-              BetterPostersSettings.applyToHomeScreen else { return }
+              BetterPostersSettings.applyToHomeScreen else {
+            betterPosterURL = nil
+            return
+        }
         let imdbId = await IMDbIDCache.shared.imdbId(tmdbId: result.id, isMovie: result.isMovie, tmdbService: .shared)
         betterPosterURL = BetterPostersSettings.posterURL(imdbId: imdbId)
     }
@@ -3056,7 +3063,7 @@ struct ExperimentalMediaCard: View {
             .frame(width: cardSize.width, alignment: .leading)
         }
         .buttonStyle(PlainButtonStyle())
-        .task(id: result.id) {
+        .task(id: betterPosterTaskKey) {
             await resolveBetterPosterIfNeeded()
         }
     }
@@ -3168,15 +3175,22 @@ struct MediaCard: View {
 #else
         .buttonStyle(PlainButtonStyle())
 #endif
-        .task(id: result.id) {
+        .task(id: betterPosterTaskKey) {
             await resolveBetterPosterIfNeeded()
         }
+    }
+
+    private var betterPosterTaskKey: String {
+        "\(result.id)-\(BetterPostersSettings.isEnabled)-\(BetterPostersSettings.applyToHomeScreen)-\(BetterPostersSettings.urlPattern ?? "")"
     }
 
     private func resolveBetterPosterIfNeeded() async {
         guard !usesBackdropCard,
               BetterPostersSettings.isEnabled,
-              BetterPostersSettings.applyToHomeScreen else { return }
+              BetterPostersSettings.applyToHomeScreen else {
+            betterPosterURL = nil
+            return
+        }
         let imdbId = await IMDbIDCache.shared.imdbId(tmdbId: result.id, isMovie: result.isMovie, tmdbService: .shared)
         betterPosterURL = BetterPostersSettings.posterURL(imdbId: imdbId)
     }
@@ -3224,33 +3238,46 @@ struct MediaCard: View {
                             .frame(maxWidth: .infinity, alignment: .center)
                     }
 
-                    if cardInfoDisplay.showsRating {
+                    if cardInfoDisplay.showsYear || cardInfoDisplay.showsRating {
                         HStack(alignment: .center, spacing: isTvOS ? 18 : 8) {
-                            HStack(alignment: .firstTextBaseline, spacing: 4) {
-                                Image(systemName: "star.fill")
-                                    .font(.caption2)
-                                    .foregroundColor(.yellow)
-
-                                Text(String(format: "%.1f", result.voteAverage ?? 0.0))
+                            if cardInfoDisplay.showsYear, let year = result.displayDate.isEmpty ? nil : String(result.displayDate.prefix(4)) {
+                                Text(year)
                                     .font(.caption2)
                                     .foregroundColor(.white)
                                     .lineLimit(1)
                                     .fixedSize()
+                                    .padding(.horizontal, isTvOS ? 16 : 8)
+                                    .padding(.vertical, isTvOS ? 10 : 4)
+                                    .applyLiquidGlassBackground(cornerRadius: 12)
                             }
-                            .padding(.horizontal, isTvOS ? 16 : 8)
-                            .padding(.vertical, isTvOS ? 10 : 4)
-                            .applyLiquidGlassBackground(cornerRadius: 12)
 
-                            Spacer()
+                            if cardInfoDisplay.showsRating {
+                                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                                    Image(systemName: "star.fill")
+                                        .font(.caption2)
+                                        .foregroundColor(.yellow)
 
-                            Text(result.isMovie ? "Movie" : "TV")
-                                .font(.caption2)
-                                .foregroundColor(.white)
-                                .lineLimit(1)
-                                .fixedSize()
+                                    Text(String(format: "%.1f", result.voteAverage ?? 0.0))
+                                        .font(.caption2)
+                                        .foregroundColor(.white)
+                                        .lineLimit(1)
+                                        .fixedSize()
+                                }
                                 .padding(.horizontal, isTvOS ? 16 : 8)
                                 .padding(.vertical, isTvOS ? 10 : 4)
                                 .applyLiquidGlassBackground(cornerRadius: 12)
+
+                                Spacer()
+
+                                Text(result.isMovie ? "Movie" : "TV")
+                                    .font(.caption2)
+                                    .foregroundColor(.white)
+                                    .lineLimit(1)
+                                    .fixedSize()
+                                    .padding(.horizontal, isTvOS ? 16 : 8)
+                                    .padding(.vertical, isTvOS ? 10 : 4)
+                                    .applyLiquidGlassBackground(cornerRadius: 12)
+                            }
                         }
                     }
                 }

--- a/Eclipse/Views/HomeView.swift
+++ b/Eclipse/Views/HomeView.swift
@@ -1669,9 +1669,9 @@ struct HomeView: View {
 
                         let displayTitle: String = {
                             if catalog.id == "becauseYouWatched" && !homeViewModel.becauseYouWatchedTitle.isEmpty {
-                                return "Because You Watched \(homeViewModel.becauseYouWatchedTitle)"
+                                return String(localized: "Because You Watched") + " " + homeViewModel.becauseYouWatchedTitle
                             }
-                            return catalog.name
+                            return String(localized: String.LocalizationValue(catalog.name))
                         }()
 
                         MediaSection(
@@ -3319,7 +3319,7 @@ struct ContinueWatchingSection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
-                Text(title)
+                Text(String(localized: String.LocalizationValue(title)))
                     .font(isTvOS ? .headline : .title2)
                     .fontWeight(.bold)
                     .foregroundColor(.white)

--- a/Eclipse/Views/MediaDetailView.swift
+++ b/Eclipse/Views/MediaDetailView.swift
@@ -434,6 +434,7 @@ struct MediaDetailContentView: View {
     @State private var synopsis: String = ""
     @State private var isBookmarked: Bool = false
     @State private var showingSearchResults = false
+    @State private var forceManualPlaybackSelection = false
     @State private var didStartWatchTogetherAutoPlay = false
     @State private var watchTogetherAutoPlayFailureCount = 0
     @State private var watchTogetherNextEpisodeAutoPlay = false
@@ -1362,6 +1363,7 @@ struct MediaDetailContentView: View {
             watchTogetherNextEpisodeAutoPlay = false
             nextEpisodePlaybackContextOverride = nil
             nextEpisodeResolvedTargetOverride = nil
+            forceManualPlaybackSelection = false
         }) {
             let exactWatchTogetherContext = exactWatchTogetherPlaybackContext(for: selectedEpisodeForSearch)
             let isWatchTogetherPlayback = watchTogetherAutoPlay != nil || watchTogetherNextEpisodeAutoPlay
@@ -1426,6 +1428,7 @@ struct MediaDetailContentView: View {
                 specialTitleOnlySearch: playbackContext?.titleOnlySearch ?? false,
                 episodePlaybackContext: playbackContext,
                 autoModeOnly: watchTogetherAutoPlay != nil || watchTogetherNextEpisodeAutoPlay || AutoModeSettings.isEnabled(),
+                ignoresAutoMode: forceManualPlaybackSelection,
                 forceAutomaticPlayback: watchTogetherAutoPlay != nil || watchTogetherNextEpisodeAutoPlay,
                 autoModeRetrySession: autoModeRetrySession,
                 autoModeRecoveryIdentity: recoveryIdentity,
@@ -1516,6 +1519,7 @@ struct MediaDetailContentView: View {
                 specialTitleOnlySearch: request.titleOnly,
                 episodePlaybackContext: request.playbackContext,
                 autoModeOnly: watchTogetherAutoPlay != nil || watchTogetherNextEpisodeAutoPlay || AutoModeSettings.isEnabled(),
+                ignoresAutoMode: forceManualPlaybackSelection,
                 forceAutomaticPlayback: watchTogetherAutoPlay != nil || watchTogetherNextEpisodeAutoPlay,
                 autoModeRetrySession: autoModeRetrySession,
                 autoModeRecoveryIdentity: recoveryIdentity,
@@ -1951,24 +1955,32 @@ struct MediaDetailContentView: View {
     @ViewBuilder
     private var iPadImmersiveActions: some View {
         HStack(spacing: 10) {
-            Button(action: searchInServices) {
-                Label(
-                    canUseMainPlayButton ? playButtonText : "No Sources",
-                    systemImage: canUseMainPlayButton ? "play.fill" : "exclamationmark.triangle"
-                )
-                .font(.headline)
-                .foregroundColor(.white)
-                .frame(maxWidth: .infinity)
-                .frame(height: 48)
-            }
-            .buttonStyle(.plain)
-            .disabled(!canUseMainPlayButton)
+            Label(
+                canUseMainPlayButton ? playButtonText : "No Sources",
+                systemImage: canUseMainPlayButton ? "play.fill" : "exclamationmark.triangle"
+            )
+            .font(.headline)
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
             .applyLiquidGlassBackground(
                 cornerRadius: 14,
                 fallbackFill: canUseMainPlayButton ? Color.white.opacity(0.11) : Color.white.opacity(0.05),
                 fallbackMaterial: .thinMaterial,
                 glassTint: canUseMainPlayButton ? Color.white.opacity(0.025) : nil
             )
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .onTapGesture {
+                guard canUseMainPlayButton else { return }
+                handlePlayTap()
+            }
+            .onLongPressGesture(minimumDuration: 0.5) {
+                guard canUseMainPlayButton else { return }
+                handlePlayLongPress()
+            }
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel(canUseMainPlayButton ? playButtonText : "No Sources")
+            .accessibilityHint("Double tap to play automatically. Touch and hold to choose a source manually.")
 
             iPadImmersiveActionButton(
                 systemName: isBookmarked ? "heart.fill" : "heart",
@@ -2619,33 +2631,51 @@ struct MediaDetailContentView: View {
     }
 
     @ViewBuilder
+    private var legacyPlayButtonLabel: some View {
+        HStack {
+            Image(systemName: canUseMainPlayButton ? "play.fill" : "exclamationmark.triangle")
+
+            Text(canUseMainPlayButton ? playButtonText : "No Sources")
+                .fontWeight(.semibold)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .padding(.horizontal, 25)
+        .applyLiquidGlassBackground(
+            cornerRadius: 12,
+            fallbackFill: canUseMainPlayButton ? Color.black.opacity(0.2) : Color.gray.opacity(0.3),
+            fallbackMaterial: canUseMainPlayButton ? .ultraThinMaterial : .thinMaterial,
+            glassTint: canUseMainPlayButton ? nil : Color.gray.opacity(0.3)
+        )
+        .foregroundColor(canUseMainPlayButton ? .white : .secondary)
+        .cornerRadius(8)
+    }
+
     private var legacyPlayAndBookmarkSection: some View {
         HStack(spacing: 8) {
+#if os(tvOS)
             Button(action: {
-                searchInServices()
+                handlePlayTap()
             }) {
-                HStack {
-                    Image(systemName: canUseMainPlayButton ? "play.fill" : "exclamationmark.triangle")
-
-                    Text(canUseMainPlayButton ? playButtonText : "No Sources")
-                        .fontWeight(.semibold)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .padding(.horizontal, 25)
-                .applyLiquidGlassBackground(
-                    cornerRadius: 12,
-                    fallbackFill: canUseMainPlayButton ? Color.black.opacity(0.2) : Color.gray.opacity(0.3),
-                    fallbackMaterial: canUseMainPlayButton ? .ultraThinMaterial : .thinMaterial,
-                    glassTint: canUseMainPlayButton ? nil : Color.gray.opacity(0.3)
-                )
-                .foregroundColor(canUseMainPlayButton ? .white : .secondary)
-                .cornerRadius(8)
+                legacyPlayButtonLabel
             }
             .disabled(!canUseMainPlayButton)
-#if os(tvOS)
             .focused($tvDetailFocus, equals: .play)
             .accessibilityIdentifier("tv.detail.play")
+#else
+            legacyPlayButtonLabel
+                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .onTapGesture {
+                    guard canUseMainPlayButton else { return }
+                    handlePlayTap()
+                }
+                .onLongPressGesture(minimumDuration: 0.5) {
+                    guard canUseMainPlayButton else { return }
+                    handlePlayLongPress()
+                }
+                .accessibilityAddTraits(.isButton)
+                .accessibilityLabel(canUseMainPlayButton ? playButtonText : "No Sources")
+                .accessibilityHint("Double tap to play automatically. Touch and hold to choose a source manually.")
 #endif
 
             Button(action: {
@@ -2719,41 +2749,41 @@ struct MediaDetailContentView: View {
     }
 
     @ViewBuilder
+    private var experimentalPlayButtonLabel: some View {
+        Text(canUseMainPlayButton ? playButtonText : "No Sources")
+            .font(.system(size: isTvOS ? 34 : (isIPad ? 25 : 22), weight: .bold))
+            .foregroundColor(canUseMainPlayButton ? .black : .white.opacity(0.62))
+            .lineLimit(1)
+            .minimumScaleFactor(0.76)
+            .frame(maxWidth: .infinity)
+            .frame(height: isTvOS ? 80 : (isIPad ? 58 : 52))
+            .background(
+                RoundedRectangle(cornerRadius: playButtonCornerRadius, style: .continuous)
+                    .fill(canUseMainPlayButton ? Color.white.opacity(0.72) : Color.white.opacity(0.16))
+                    .background(
+                        RoundedRectangle(cornerRadius: playButtonCornerRadius, style: .continuous)
+                            .fill(.ultraThinMaterial)
+                            .opacity(0.72)
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: playButtonCornerRadius, style: .continuous)
+                    .stroke(Color.white.opacity(0.32), lineWidth: 1)
+            )
+    }
+
     private var experimentalPlayAndBookmarkSection: some View {
         VStack(spacing: isTvOS ? 30 : (isIPad ? 18 : 15)) {
-            Button(action: {
 #if os(tvOS)
+            Button(action: {
                 if canUseMainPlayButton {
-                    searchInServices()
+                    handlePlayTap()
                 } else {
                     showingTVNoSourcesGuidance = true
                 }
-#else
-                searchInServices()
-#endif
             }) {
-                Text(canUseMainPlayButton ? playButtonText : "No Sources")
-                    .font(.system(size: isTvOS ? 34 : (isIPad ? 25 : 22), weight: .bold))
-                    .foregroundColor(canUseMainPlayButton ? .black : .white.opacity(0.62))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.76)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: isTvOS ? 80 : (isIPad ? 58 : 52))
-                    .background(
-                        RoundedRectangle(cornerRadius: playButtonCornerRadius, style: .continuous)
-                            .fill(canUseMainPlayButton ? Color.white.opacity(0.72) : Color.white.opacity(0.16))
-                            .background(
-                                RoundedRectangle(cornerRadius: playButtonCornerRadius, style: .continuous)
-                                    .fill(.ultraThinMaterial)
-                                    .opacity(0.72)
-                            )
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: playButtonCornerRadius, style: .continuous)
-                            .stroke(Color.white.opacity(0.32), lineWidth: 1)
-                    )
+                experimentalPlayButtonLabel
             }
-#if os(tvOS)
             .buttonStyle(TVMediaCardButtonStyle())
             .accessibilityLabel(canUseMainPlayButton ? playButtonText : "No playable source")
             .accessibilityHint(canUseMainPlayButton ? "Finds a stream and starts playback." : "Explains how to add a source.")
@@ -2765,8 +2795,19 @@ struct MediaDetailContentView: View {
                 Text("Eclipse ships without content sources. Add a Service or Stremio addon in Settings › Services, then come back to play this title.")
             }
 #else
-            .buttonStyle(PlainButtonStyle())
-            .disabled(!canUseMainPlayButton)
+            experimentalPlayButtonLabel
+                .contentShape(RoundedRectangle(cornerRadius: playButtonCornerRadius, style: .continuous))
+                .onTapGesture {
+                    guard canUseMainPlayButton else { return }
+                    handlePlayTap()
+                }
+                .onLongPressGesture(minimumDuration: 0.5) {
+                    guard canUseMainPlayButton else { return }
+                    handlePlayLongPress()
+                }
+                .accessibilityAddTraits(.isButton)
+                .accessibilityLabel(canUseMainPlayButton ? playButtonText : "No Sources")
+                .accessibilityHint("Double tap to play automatically. Touch and hold to choose a source manually.")
 #endif
 
             HStack(spacing: isTvOS ? 44 : (isIPad ? 30 : 22)) {
@@ -4568,9 +4609,18 @@ struct MediaDetailContentView: View {
         }
     }
 
+    private func handlePlayTap() {
+        forceManualPlaybackSelection = false
+        searchInServices()
+    }
+
+    private func handlePlayLongPress() {
+        forceManualPlaybackSelection = true
+        searchInServices()
+    }
+
     private func searchInServices() {
-        if searchResult.isMovie {
-            selectedEpisodeForSearch = nil
+        if searchResult.isMovie {            selectedEpisodeForSearch = nil
 #if !os(tvOS)
             if preferDownloadedMedia,
                let item = downloadManager.completedDownloadItem(tmdbId: searchResult.id, isMovie: true) {

--- a/Eclipse/Views/SettingsView.swift
+++ b/Eclipse/Views/SettingsView.swift
@@ -112,6 +112,7 @@ struct SettingsView: View {
 
     private static let baseSettingsSearchEntries: [SettingsSearchEntry] = {
         var entries: [SettingsSearchEntry] = [
+            .init(id: "language", title: "Language", location: "Basic", icon: "globe", color: .blue, keywords: ["interface language", "translation", "español", "spanish", "locale"], action: .destination(.language)),
             .init(id: "performance-mode", title: "Performance Mode", location: "Basic", icon: "bolt.fill", color: .yellow, keywords: ["fast", "AniList", "catalog"], action: .destination(.performance)),
             .init(id: "media-player", title: "Media Player", location: "Basic", icon: "play.fill", color: .white, keywords: ["MPV", "VLC", "AVPlayer", "default player"], action: .destination(.player)),
             .init(id: "playback-speed", title: "Default Playback Speed", location: "Media Player > Default Player", icon: "gauge.with.dots.needle.50percent", color: .orange, keywords: ["playback speed", "rate", "speed"], action: .destination(.playerTarget(.defaultPlaybackSpeed))),
@@ -512,6 +513,22 @@ struct SettingsView: View {
 
                 GlassSection(header: "Basic") {
                     VStack(spacing: 0) {
+                        NavigationLink(destination: settingsSearchableContent(LanguageSettingsView())) {
+                            GlassSettingsRow(icon: "globe", iconColor: .blue, title: "Language") {
+                                HStack(spacing: 4) {
+                                    Text(AppLanguageOption.current.displayName)
+                                        .font(.subheadline)
+                                        .foregroundColor(.white.opacity(0.5))
+                                    Image(systemName: "chevron.right")
+                                        .font(.system(size: 13, weight: .semibold))
+                                        .foregroundColor(.white.opacity(0.3))
+                                }
+                            }
+                        }
+                        .buttonStyle(.plain)
+
+                        GlassDivider()
+
                         NavigationLink(destination: settingsSearchableContent(PerformanceModeSettingsView())) {
                             GlassSettingsRow(icon: "bolt.fill", iconColor: .yellow, title: "Performance Mode") {
                                 HStack(spacing: 4) {
@@ -921,6 +938,8 @@ struct SettingsView: View {
 
     private func settingsSearchDestination(_ destination: SettingsSearchDestination) -> AnyView {
         switch destination {
+        case .language:
+            return AnyView(settingsSearchableContent(LanguageSettingsView()))
         case .performance:
             return AnyView(settingsSearchableContent(PerformanceModeSettingsView()))
         case .player:
@@ -1177,6 +1196,7 @@ struct SettingsSearchContainer<Content: View>: View {
 }
 
 private enum SettingsSearchDestination: Hashable {
+    case language
     case performance
     case player
     case playerTarget(PlayerSettingsSearchTarget)

--- a/Eclipse/Views/SettingsView/AlternativeUIView.swift
+++ b/Eclipse/Views/SettingsView/AlternativeUIView.swift
@@ -204,7 +204,7 @@ struct AlternativeUIView: View {
             } label: {
                 appearanceCategoryLabel(
                     title: "Home Layout",
-                    description: "Size and orientation of home rows, globally or per catalog.",
+                    description: "Layout density, roundness, spacing, and the animated background.",
                     systemImage: "rectangle.grid.1x2"
                 )
             }

--- a/Eclipse/Views/SettingsView/CatalogsSettingsView.swift
+++ b/Eclipse/Views/SettingsView/CatalogsSettingsView.swift
@@ -11,7 +11,17 @@ struct CatalogsSettingsView: View {
     @ObservedObject private var catalogManager = CatalogManager.shared
     @ObservedObject private var trackerManager = TrackerManager.shared
     @StateObject private var accentColorManager = AccentColorManager.shared
+    @StateObject private var layoutStore = HomeCatalogLayoutStore.shared
     @State private var editMode = EditMode.active
+    @State private var layoutEditorCatalog: Catalog?
+    @State private var isLayoutEditorActive = false
+
+    @AppStorage(ExperimentalHomeCardShape.storageKey) private var globalCardShape = ExperimentalHomeCardShape.defaultValue.rawValue
+    @AppStorage(HomeCardInfoDisplay.storageKey) private var globalCardInfoDisplay = HomeCardInfoDisplay.defaultValue.rawValue
+    @AppStorage(ExperimentalVisualTuning.mediaCardScaleKey) private var globalCardScale = ExperimentalVisualTuning.defaultMediaCardScale
+    @AppStorage(BetterPostersSettings.enabledKey) private var betterPostersEnabled = BetterPostersSettings.defaultEnabled
+    @AppStorage(BetterPostersSettings.urlPatternKey) private var betterPostersURLPattern = ""
+    @AppStorage(BetterPostersSettings.applyToHomeKey) private var betterPostersApplyToHome = BetterPostersSettings.defaultApplyToHome
 
     var body: some View {
         catalogsContent
@@ -24,6 +34,24 @@ struct CatalogsSettingsView: View {
             .onAppear {
                 StremioAddonManager.shared.loadAddons()
             }
+            .background(layoutEditorNavigationLink)
+    }
+
+    @ViewBuilder
+    private var layoutEditorNavigationLink: some View {
+        NavigationLink(
+            destination: Group {
+                if let layoutEditorCatalog {
+                    CatalogLayoutEditorView(catalog: layoutEditorCatalog)
+                } else {
+                    EmptyView()
+                }
+            },
+            isActive: $isLayoutEditorActive
+        ) {
+            EmptyView()
+        }
+        .opacity(0)
     }
 
     @ViewBuilder
@@ -31,6 +59,10 @@ struct CatalogsSettingsView: View {
 #if os(tvOS)
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 22) {
+                homeLayoutSection
+
+                betterPostersSection
+
                 Text("Content Catalogs")
                     .font(.title2.weight(.semibold))
 
@@ -39,6 +71,14 @@ struct CatalogsSettingsView: View {
                         catalogIdentity(catalog)
 
                         Spacer(minLength: 20)
+
+                        Button {
+                            layoutEditorCatalog = catalog
+                            isLayoutEditorActive = true
+                        } label: {
+                            Label("Customize", systemImage: "slider.horizontal.3")
+                        }
+                        .accessibilityIdentifier("tv.catalog.\(catalog.id).customize")
 
                         Toggle("Enabled", isOn: Binding(
                             get: { catalogManager.isCatalogEffectivelyEnabled(catalog) },
@@ -77,7 +117,7 @@ struct CatalogsSettingsView: View {
                     .focusSection()
                 }
 
-                Text("Enable or disable content catalogs and use the arrow buttons to reorder them. The order here determines the order on your home screen.")
+                Text("Enable or disable content catalogs and use the arrow buttons to reorder them. The order here determines the order on your home screen. Use Customize to override orientation, size, and card info per catalog.")
                     .font(.footnote)
                     .foregroundColor(.secondary)
                     .padding(.horizontal, 8)
@@ -87,6 +127,10 @@ struct CatalogsSettingsView: View {
         }
 #else
         List {
+            homeLayoutSection
+
+            betterPostersSection
+
             Section {
                 ForEach(catalogManager.visibleCatalogs) { catalog in
                     HStack {
@@ -111,10 +155,26 @@ struct CatalogsSettingsView: View {
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
+
+                                if layoutStore.hasOverride(for: catalog.id) {
+                                    Text("\u{00B7} Custom")
+                                        .font(.caption)
+                                        .foregroundColor(accentColorManager.currentAccentColor)
+                                }
                             }
                         }
 
                         Spacer()
+
+                        Button {
+                            layoutEditorCatalog = catalog
+                            isLayoutEditorActive = true
+                        } label: {
+                            Image(systemName: "slider.horizontal.3")
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Customize \(catalog.name)")
 
                         Toggle("", isOn: Binding(
                             get: { catalogManager.isCatalogEffectivelyEnabled(catalog) },
@@ -128,12 +188,89 @@ struct CatalogsSettingsView: View {
             } header: {
                 Text("Content Catalogs")
             } footer: {
-                Text("Enable/disable content catalogs and drag to reorder them. The order here determines the order on your home screen. Stremio catalog addons may reduce performance or have visual inconsistencies. Trakt catalogs appear after Trakt is connected.")
+                Text("Enable/disable content catalogs and drag to reorder them. The order here determines the order on your home screen. Tap the slider icon to customize orientation, size, and card info for a single catalog. Stremio catalog addons may reduce performance or have visual inconsistencies. Trakt catalogs appear after Trakt is connected.")
             }
             .eclipseExperimentalSettingsRows()
             .background(EclipseScrollTracker())
         }
 #endif
+    }
+
+    private var betterPostersSection: some View {
+        Section {
+            Toggle("Enable Better Posters", isOn: $betterPostersEnabled)
+                .tint(accentColorManager.currentAccentColor)
+
+            if betterPostersEnabled {
+                TextField("Poster URL Pattern", text: $betterPostersURLPattern)
+#if !os(tvOS)
+                    .textInputAutocapitalization(.never)
+#endif
+                    .autocorrectionDisabled()
+
+                Toggle("Apply to Home Screen", isOn: $betterPostersApplyToHome)
+                    .tint(accentColorManager.currentAccentColor)
+            }
+        } header: {
+            Text("Poster Artwork")
+        } footer: {
+            if betterPostersEnabled {
+                Text("Paste the URL from btttr.cc/configure (\"AIOMetadata / Other Addon\" \u{2192} \"I already have catalogs, just give me the poster URL\"). It should contain \(BetterPostersSettings.placeholderToken). Applying to the Home Screen looks up each title's IMDb id the first time it's shown and may use more data; it's off by default. Detail pages are unaffected for now.")
+            } else {
+                Text("Replace poster artwork with images from Better Posters (btttr.cc), a community poster service.")
+            }
+        }
+        .eclipseExperimentalSettingsRows()
+    }
+
+    private var homeLayoutSection: some View {        Section {
+            Picker("Orientation", selection: $globalCardShape) {
+                ForEach(ExperimentalHomeCardShape.allCases) { option in
+                    Text(option.displayName).tag(option.rawValue)
+                }
+            }
+            .pickerStyle(.menu)
+
+            Picker("Card Info", selection: $globalCardInfoDisplay) {
+                ForEach(HomeCardInfoDisplay.allCases) { option in
+                    Text(option.displayName).tag(option.rawValue)
+                }
+            }
+            .pickerStyle(.menu)
+
+#if !os(tvOS)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Size")
+                    Spacer()
+                    Text(String(format: "%.2fx", globalCardScale))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .monospacedDigit()
+                }
+                Slider(value: $globalCardScale, in: HomeCatalogLayoutStore.sizeRange, step: 0.05)
+                    .tint(accentColorManager.currentAccentColor)
+            }
+#endif
+
+            Button(role: .destructive) {
+                layoutStore.resetAll()
+            } label: {
+                HStack {
+                    Text("Reset All Catalogs")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    Spacer()
+                    Image(systemName: "arrow.counterclockwise")
+                        .foregroundColor(accentColorManager.currentAccentColor)
+                }
+            }
+        } header: {
+            Text("Home Layout")
+        } footer: {
+            Text("Orientation, size, and card info (title, year, rating) apply to every catalog on the home screen by default. Use the slider icon on a catalog below to override any of these just for that catalog.")
+        }
+        .eclipseExperimentalSettingsRows()
     }
 
     private func catalogIdentity(_ catalog: Catalog) -> some View {
@@ -156,6 +293,12 @@ struct CatalogsSettingsView: View {
                     Text("\u{00B7} \(displayStyleText(for: catalog.displayStyle))")
                         .font(.caption)
                         .foregroundColor(.secondary)
+                }
+
+                if layoutStore.hasOverride(for: catalog.id) {
+                    Text("\u{00B7} Custom")
+                        .font(.caption)
+                        .foregroundColor(accentColorManager.currentAccentColor)
                 }
             }
         }
@@ -198,5 +341,158 @@ struct CatalogsSettingsView: View {
         default:
             return style.rawValue.capitalized
         }
+    }
+}
+
+struct CatalogLayoutEditorView: View {
+    let catalog: Catalog
+
+    @StateObject private var layoutStore = HomeCatalogLayoutStore.shared
+    @StateObject private var accentColorManager = AccentColorManager.shared
+    @AppStorage(ExperimentalVisualTuning.mediaCardScaleKey) private var globalCardScale = ExperimentalVisualTuning.defaultMediaCardScale
+
+    private var accent: Color { accentColorManager.currentAccentColor }
+    private var supportsOrientation: Bool { catalog.displayStyle == .standard }
+    private var effectiveGlobalCardScale: Double {
+#if os(tvOS)
+        ExperimentalVisualTuning.current.mediaCardScale
+#else
+        globalCardScale
+#endif
+    }
+
+    var body: some View {
+        List {
+            if supportsOrientation {
+                Section {
+                    Picker("Orientation", selection: orientationBinding) {
+                        ForEach(CatalogOrientationOverride.allCases) { option in
+                            Text(option.displayName).tag(option)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                } header: {
+                    Text("Orientation")
+                } footer: {
+#if os(tvOS)
+                    Text("Global follows the Catalogs orientation. Automatic chooses one orientation per shelf, using posters for anime or missing backdrop artwork.")
+#else
+                    Text("Global follows the Catalogs orientation. Automatic picks poster or landscape per item.")
+#endif
+                }
+                .eclipseExperimentalSettingsRows()
+            }
+
+            Section {
+                Picker("Card Info", selection: cardInfoBinding) {
+                    Text("Global").tag(Optional<HomeCardInfoDisplay>.none)
+                    ForEach(HomeCardInfoDisplay.allCases) { option in
+                        Text(option.displayName).tag(Optional(option))
+                    }
+                }
+                .pickerStyle(.menu)
+            } header: {
+                Text("Card Info")
+            } footer: {
+                Text("Global follows the Catalogs card info setting. Choose title, year, rating, any combination, or poster only, just for this catalog.")
+            }
+            .eclipseExperimentalSettingsRows()
+
+            Section {
+                Toggle("Custom size", isOn: customSizeBinding)
+                    .tint(accent)
+
+                if let _ = layoutStore.override(for: catalog.id).sizeScale {
+                    HStack {
+                        Text("Size")
+                            .font(.subheadline)
+                        Spacer()
+                        Text(String(format: "%.2fx", sizeValueBinding.wrappedValue))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .monospacedDigit()
+                    }
+#if os(tvOS)
+                    HStack(spacing: 18) {
+                        Button {
+                            sizeValueBinding.wrappedValue = max(
+                                HomeCatalogLayoutStore.sizeRange.lowerBound,
+                                sizeValueBinding.wrappedValue - 0.05
+                            )
+                        } label: {
+                            Label("Decrease Size", systemImage: "minus")
+                        }
+                        .disabled(sizeValueBinding.wrappedValue <= HomeCatalogLayoutStore.sizeRange.lowerBound)
+
+                        Button {
+                            sizeValueBinding.wrappedValue = min(
+                                HomeCatalogLayoutStore.sizeRange.upperBound,
+                                sizeValueBinding.wrappedValue + 0.05
+                            )
+                        } label: {
+                            Label("Increase Size", systemImage: "plus")
+                        }
+                        .disabled(sizeValueBinding.wrappedValue >= HomeCatalogLayoutStore.sizeRange.upperBound)
+                    }
+#else
+                    Slider(value: sizeValueBinding, in: HomeCatalogLayoutStore.sizeRange, step: 0.05)
+                        .tint(accent)
+#endif
+                }
+            } header: {
+                Text("Size")
+            } footer: {
+                Text("Off follows the global size. Widget rows support size only.")
+            }
+            .eclipseExperimentalSettingsRows()
+
+            Section {
+                Button(role: .destructive) {
+                    layoutStore.reset(id: catalog.id)
+                } label: {
+                    HStack {
+                        Text("Reset to Global")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Spacer()
+                        Image(systemName: "arrow.counterclockwise")
+                            .foregroundColor(accent)
+                    }
+                }
+            }
+            .eclipseExperimentalSettingsRows()
+        }
+        .eclipsePageTitle(catalog.name)
+        .eclipseSettingsStyle()
+    }
+
+    private var orientationBinding: Binding<CatalogOrientationOverride> {
+        Binding(
+            get: { layoutStore.override(for: catalog.id).orientation },
+            set: { layoutStore.setOrientation($0, for: catalog.id) }
+        )
+    }
+
+    private var cardInfoBinding: Binding<HomeCardInfoDisplay?> {
+        Binding(
+            get: { layoutStore.override(for: catalog.id).cardInfoDisplay },
+            set: { layoutStore.setCardInfoDisplay($0, for: catalog.id) }
+        )
+    }
+
+    private var customSizeBinding: Binding<Bool> {
+        Binding(
+            get: { layoutStore.override(for: catalog.id).sizeScale != nil },
+            set: { isOn in
+                layoutStore.setSizeScale(isOn ? effectiveGlobalCardScale : nil, for: catalog.id)
+            }
+        )
+    }
+
+    private var sizeValueBinding: Binding<Double> {
+        Binding(
+            get: { layoutStore.override(for: catalog.id).sizeScale ?? effectiveGlobalCardScale },
+            set: { layoutStore.setSizeScale($0, for: catalog.id) }
+        )
     }
 }

--- a/Eclipse/Views/SettingsView/HomeLayoutView.swift
+++ b/Eclipse/Views/SettingsView/HomeLayoutView.swift
@@ -21,8 +21,6 @@ private enum TVCardDensity: String, CaseIterable, Identifiable {
 
 struct HomeLayoutView: View {
 
-    @AppStorage(ExperimentalHomeCardShape.storageKey) private var globalCardShape = ExperimentalHomeCardShape.defaultValue.rawValue
-    @AppStorage(ExperimentalVisualTuning.mediaCardScaleKey) private var globalCardScale = ExperimentalVisualTuning.defaultMediaCardScale
     @AppStorage(ExperimentalMediaDesignPreset.storageKey) private var designPreset = ExperimentalMediaDesignPreset.defaultValue.rawValue
     @AppStorage(ExperimentalVisualTuning.cardRadiusScaleKey) private var cardRadiusScale = ExperimentalVisualTuning.defaultCardRadiusScale
     @AppStorage(ExperimentalVisualTuning.sectionSpacingScaleKey) private var sectionSpacingScale = ExperimentalVisualTuning.defaultSectionSpacingScale
@@ -38,7 +36,6 @@ struct HomeLayoutView: View {
     @AppStorage("heroBannerBehavior") private var heroBannerBehavior = HeroBannerBehavior.defaultValue.rawValue
 
     @StateObject private var catalogManager = CatalogManager.shared
-    @StateObject private var layoutStore = HomeCatalogLayoutStore.shared
     @StateObject private var accentColorManager = AccentColorManager.shared
 
     private var accent: Color { accentColorManager.currentAccentColor }
@@ -52,8 +49,6 @@ struct HomeLayoutView: View {
             globalSection
                 .eclipseExperimentalSettingsRows()
             heroSection
-                .eclipseExperimentalSettingsRows()
-            perCatalogSection
                 .eclipseExperimentalSettingsRows()
         }
         .eclipsePageTitle("Home Layout")
@@ -69,13 +64,6 @@ struct HomeLayoutView: View {
 
     private var globalSection: some View {
         Section {
-            pickerRow(
-                title: "Orientation",
-                description: "Whether shelves prefer poster (tall) or landscape (wide) artwork.",
-                selection: $globalCardShape,
-                values: ExperimentalHomeCardShape.allCases.map { ($0.rawValue, $0.displayName) }
-            )
-
 #if os(tvOS)
             pickerRow(
                 title: "Card Density",
@@ -88,15 +76,6 @@ struct HomeLayoutView: View {
                     }
                 ),
                 values: TVCardDensity.allCases.map { ($0.rawValue, $0.displayName) }
-            )
-#else
-            sliderRow(
-                title: "Size",
-                description: "Scale every home row's cards and widgets.",
-                value: $globalCardScale,
-                range: HomeCatalogLayoutStore.sizeRange,
-                step: 0.05,
-                format: "%.2fx"
             )
 #endif
 
@@ -152,7 +131,7 @@ struct HomeLayoutView: View {
         } header: {
             Text("Global")
         } footer: {
-            Text("These apply to every home row. Override individual rows below.")
+            Text("Orientation, card size and card info (title, year, rating) moved to Settings > Catalogs, where they can also be customized per catalog.")
         }
     }
 
@@ -184,54 +163,6 @@ struct HomeLayoutView: View {
         } header: {
             Text("Hero")
         }
-    }
-
-    private var perCatalogSection: some View {
-        Section {
-            ForEach(sortedCatalogs) { catalog in
-                NavigationLink {
-                    CatalogLayoutEditorView(catalog: catalog)
-                } label: {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(catalog.name)
-                                .font(.subheadline)
-                                .fontWeight(.medium)
-                            Text(summary(for: catalog))
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                        Spacer()
-                    }
-                }
-            }
-
-            Button(role: .destructive) {
-                layoutStore.resetAll()
-            } label: {
-                HStack {
-                    Text("Reset All Catalogs")
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                    Spacer()
-                    Image(systemName: "arrow.counterclockwise")
-                        .foregroundColor(accent)
-                }
-            }
-        } header: {
-            Text("Per Catalog")
-        } footer: {
-            Text("Rows set to Global follow the settings above. Orientation applies to standard poster rows; widget rows support size only.")
-        }
-    }
-
-    private func summary(for catalog: Catalog) -> String {
-        let override = layoutStore.override(for: catalog.id)
-        guard !override.isEmpty else { return "Global" }
-        var parts: [String] = []
-        if override.orientation != .global { parts.append(override.orientation.displayName) }
-        if let scale = override.sizeScale { parts.append(String(format: "%.2fx", scale)) }
-        return parts.isEmpty ? "Global" : parts.joined(separator: " · ")
     }
 
     private var heroBehaviorBinding: Binding<String> {
@@ -323,136 +254,5 @@ struct HomeLayoutView: View {
 #endif
         }
         .padding(.vertical, 2)
-    }
-}
-
-private struct CatalogLayoutEditorView: View {
-    let catalog: Catalog
-
-    @StateObject private var layoutStore = HomeCatalogLayoutStore.shared
-    @StateObject private var accentColorManager = AccentColorManager.shared
-    @AppStorage(ExperimentalVisualTuning.mediaCardScaleKey) private var globalCardScale = ExperimentalVisualTuning.defaultMediaCardScale
-
-    private var accent: Color { accentColorManager.currentAccentColor }
-    private var supportsOrientation: Bool { catalog.displayStyle == .standard }
-    private var effectiveGlobalCardScale: Double {
-#if os(tvOS)
-        ExperimentalVisualTuning.current.mediaCardScale
-#else
-        globalCardScale
-#endif
-    }
-
-    var body: some View {
-        List {
-            if supportsOrientation {
-                Section {
-                    Picker("Orientation", selection: orientationBinding) {
-                        ForEach(CatalogOrientationOverride.allCases) { option in
-                            Text(option.displayName).tag(option)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                } header: {
-                    Text("Orientation")
-                } footer: {
-#if os(tvOS)
-                    Text("Global follows the Home Layout orientation. Automatic chooses one orientation per shelf, using posters for anime or missing backdrop artwork.")
-#else
-                    Text("Global follows the Home Layout orientation. Automatic picks poster or landscape per item.")
-#endif
-                }
-                .eclipseExperimentalSettingsRows()
-            }
-
-            Section {
-                Toggle("Custom size", isOn: customSizeBinding)
-                    .tint(accent)
-
-                if let _ = layoutStore.override(for: catalog.id).sizeScale {
-                    HStack {
-                        Text("Size")
-                            .font(.subheadline)
-                        Spacer()
-                        Text(String(format: "%.2fx", sizeValueBinding.wrappedValue))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .monospacedDigit()
-                    }
-#if os(tvOS)
-                    HStack(spacing: 18) {
-                        Button {
-                            sizeValueBinding.wrappedValue = max(
-                                HomeCatalogLayoutStore.sizeRange.lowerBound,
-                                sizeValueBinding.wrappedValue - 0.05
-                            )
-                        } label: {
-                            Label("Decrease Size", systemImage: "minus")
-                        }
-                        .disabled(sizeValueBinding.wrappedValue <= HomeCatalogLayoutStore.sizeRange.lowerBound)
-
-                        Button {
-                            sizeValueBinding.wrappedValue = min(
-                                HomeCatalogLayoutStore.sizeRange.upperBound,
-                                sizeValueBinding.wrappedValue + 0.05
-                            )
-                        } label: {
-                            Label("Increase Size", systemImage: "plus")
-                        }
-                        .disabled(sizeValueBinding.wrappedValue >= HomeCatalogLayoutStore.sizeRange.upperBound)
-                    }
-#else
-                    Slider(value: sizeValueBinding, in: HomeCatalogLayoutStore.sizeRange, step: 0.05)
-                        .tint(accent)
-#endif
-                }
-            } header: {
-                Text("Size")
-            } footer: {
-                Text("Off follows the global size. Widget rows support size only.")
-            }
-            .eclipseExperimentalSettingsRows()
-
-            Section {
-                Button(role: .destructive) {
-                    layoutStore.reset(id: catalog.id)
-                } label: {
-                    HStack {
-                        Text("Reset to Global")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                        Spacer()
-                        Image(systemName: "arrow.counterclockwise")
-                            .foregroundColor(accent)
-                    }
-                }
-            }
-            .eclipseExperimentalSettingsRows()
-        }
-        .eclipsePageTitle(catalog.name)
-        .eclipseSettingsStyle()
-    }
-
-    private var orientationBinding: Binding<CatalogOrientationOverride> {
-        Binding(
-            get: { layoutStore.override(for: catalog.id).orientation },
-            set: { layoutStore.setOrientation($0, for: catalog.id) }
-        )
-    }
-
-    private var customSizeBinding: Binding<Bool> {
-        Binding(
-            get: { layoutStore.override(for: catalog.id).sizeScale != nil },
-            set: { isOn in
-                layoutStore.setSizeScale(isOn ? effectiveGlobalCardScale : nil, for: catalog.id)
-            }
-        )
-    }
-
-    private var sizeValueBinding: Binding<Double> {
-        Binding(
-            get: { layoutStore.override(for: catalog.id).sizeScale ?? effectiveGlobalCardScale },
-            set: { layoutStore.setSizeScale($0, for: catalog.id) }
-        )
     }
 }

--- a/Eclipse/Views/SettingsView/LanguageSettingsView.swift
+++ b/Eclipse/Views/SettingsView/LanguageSettingsView.swift
@@ -1,0 +1,92 @@
+
+import SwiftUI
+
+enum AppLanguageOption: String, CaseIterable, Identifiable {
+    static let storageKey = "appLanguageOverride"
+
+    case system
+    case en
+    case es
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .system: return "System Default"
+        case .en: return "English (US)"
+        case .es: return "Español"
+        }
+    }
+
+    var appleLanguageCode: String? {
+        switch self {
+        case .system: return nil
+        case .en: return "en"
+        case .es: return "es"
+        }
+    }
+
+    static var current: AppLanguageOption {
+        let raw = UserDefaults.standard.string(forKey: storageKey)
+        return AppLanguageOption(rawValue: raw ?? "") ?? .system
+    }
+}
+
+struct LanguageSettingsView: View {
+    @AppStorage(AppLanguageOption.storageKey) private var selectedRaw = AppLanguageOption.system.rawValue
+    @State private var showRestartAlert = false
+    @StateObject private var accentColorManager = AccentColorManager.shared
+
+    private var accent: Color { accentColorManager.currentAccentColor }
+
+    private var selected: AppLanguageOption {
+        AppLanguageOption(rawValue: selectedRaw) ?? .system
+    }
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(AppLanguageOption.allCases) { option in
+                    Button {
+                        applySelection(option)
+                    } label: {
+                        HStack {
+                            Text(option.displayName)
+                                .foregroundColor(.primary)
+                            Spacer()
+                            if option == selected {
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(accent)
+                            }
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            } footer: {
+                Text("Translations are community-contributed and still a work in progress, so some screens may still show English text. Eclipse applies the interface language the next time it launches.")
+            }
+        }
+        .eclipsePageTitle("Language")
+        .accessibilityIdentifier("tv.settings.language.screen")
+        .eclipseSettingsStyle()
+        .alert("Restart Required", isPresented: $showRestartAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Restart Eclipse to finish switching the interface language.")
+        }
+    }
+
+    private func applySelection(_ option: AppLanguageOption) {
+        guard option != selected else { return }
+        selectedRaw = option.rawValue
+
+        if let code = option.appleLanguageCode {
+            UserDefaults.standard.set([code], forKey: "AppleLanguages")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+        }
+
+        showRestartAlert = true
+    }
+}

--- a/Eclipse/Views/SettingsView/LanguageSettingsView.swift
+++ b/Eclipse/Views/SettingsView/LanguageSettingsView.swift
@@ -1,10 +1,6 @@
-
 import SwiftUI
 
 enum AppLanguageOption: String, CaseIterable, Identifiable {
-    static let storageKey = "appLanguageOverride"
-
-    case system
     case en
     case es
 
@@ -12,35 +8,38 @@ enum AppLanguageOption: String, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
-        case .system: return "System Default"
         case .en: return "English (US)"
         case .es: return "Español"
         }
     }
 
-    var appleLanguageCode: String? {
+    var tmdbLanguageCode: String {
         switch self {
-        case .system: return nil
-        case .en: return "en"
-        case .es: return "es"
+        case .en: return "en-US"
+        case .es: return "es-MX"
         }
     }
 
+    static func from(tmdbLanguageCode: String) -> AppLanguageOption {
+        tmdbLanguageCode.hasPrefix("es") ? .es : .en
+    }
+
     static var current: AppLanguageOption {
-        let raw = UserDefaults.standard.string(forKey: storageKey)
-        return AppLanguageOption(rawValue: raw ?? "") ?? .system
+        let stored = ProfileSettingsStore.active.string(forKey: LocalizationManager.tmdbLanguageKey)
+            ?? LocalizationManager.defaultTMDBCode
+        return from(tmdbLanguageCode: stored)
     }
 }
 
 struct LanguageSettingsView: View {
-    @AppStorage(AppLanguageOption.storageKey) private var selectedRaw = AppLanguageOption.system.rawValue
-    @State private var showRestartAlert = false
+    @AppStorage(LocalizationManager.tmdbLanguageKey, store: ProfileSettingsStore.active)
+    private var tmdbLanguage = LocalizationManager.defaultTMDBCode
     @StateObject private var accentColorManager = AccentColorManager.shared
 
     private var accent: Color { accentColorManager.currentAccentColor }
 
     private var selected: AppLanguageOption {
-        AppLanguageOption(rawValue: selectedRaw) ?? .system
+        AppLanguageOption.from(tmdbLanguageCode: tmdbLanguage)
     }
 
     var body: some View {
@@ -48,7 +47,7 @@ struct LanguageSettingsView: View {
             Section {
                 ForEach(AppLanguageOption.allCases) { option in
                     Button {
-                        applySelection(option)
+                        tmdbLanguage = option.tmdbLanguageCode
                     } label: {
                         HStack {
                             Text(option.displayName)
@@ -64,29 +63,11 @@ struct LanguageSettingsView: View {
                     .buttonStyle(.plain)
                 }
             } footer: {
-                Text("Translations are community-contributed and still a work in progress, so some screens may still show English text. Eclipse applies the interface language the next time it launches.")
+                Text("This also sets the language Eclipse requests movie and show info in. Translations are community-contributed and still a work in progress, so some screens may still show English text.")
             }
         }
         .eclipsePageTitle("Language")
         .accessibilityIdentifier("tv.settings.language.screen")
         .eclipseSettingsStyle()
-        .alert("Restart Required", isPresented: $showRestartAlert) {
-            Button("OK", role: .cancel) { }
-        } message: {
-            Text("Restart Eclipse to finish switching the interface language.")
-        }
-    }
-
-    private func applySelection(_ option: AppLanguageOption) {
-        guard option != selected else { return }
-        selectedRaw = option.rawValue
-
-        if let code = option.appleLanguageCode {
-            UserDefaults.standard.set([code], forKey: "AppleLanguages")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "AppleLanguages")
-        }
-
-        showRestartAlert = true
     }
 }

--- a/Eclipse/Views/View Elements/GradientBackground.swift
+++ b/Eclipse/Views/View Elements/GradientBackground.swift
@@ -93,6 +93,40 @@ enum ExperimentalHomeCardShape: String, CaseIterable, Identifiable {
     }
 }
 
+enum HomeCardInfoDisplay: String, Codable, CaseIterable, Identifiable {
+    static let storageKey = "homeCardInfoDisplay"
+
+    case full
+    case titleOnly
+    case titleAndYear
+    case titleAndRating
+    case posterOnly
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .full: return "Title, Year & Rating"
+        case .titleOnly: return "Title Only"
+        case .titleAndYear: return "Title & Year"
+        case .titleAndRating: return "Title & Rating"
+        case .posterOnly: return "Poster Only"
+        }
+    }
+
+    var showsTitle: Bool { self != .posterOnly }
+    var showsYear: Bool { self == .full || self == .titleAndYear }
+    var showsRating: Bool { self == .full || self == .titleAndRating }
+    var showsAnyText: Bool { self != .posterOnly }
+
+    static var defaultValue: HomeCardInfoDisplay { .full }
+
+    static var current: HomeCardInfoDisplay {
+        let rawValue = ProfileSettingsStore.active.string(forKey: storageKey)
+        return HomeCardInfoDisplay(rawValue: rawValue ?? "") ?? defaultValue
+    }
+}
+
 enum ExperimentalMultiGradientPalette: String, CaseIterable, Identifiable {
     static let storageKey = "experimentalMultiGradientPalette"
 

--- a/Eclipse/Views/View Elements/HomeWidgets.swift
+++ b/Eclipse/Views/View Elements/HomeWidgets.swift
@@ -29,7 +29,7 @@ struct NetworkSectionWidget: View {
 
         if !availableNetworks.isEmpty {
             VStack(alignment: .leading, spacing: ExperimentalFeatureState.isEnabledAtLaunch ? 18 : 16) {
-                Text(HomeWidgetTitle.forCatalog("networks"))
+                Text(String(localized: String.LocalizationValue(HomeWidgetTitle.forCatalog("networks"))))
                     .font(isTvOS ? .headline : (ExperimentalFeatureState.isEnabledAtLaunch ? .system(size: isIPad ? 34 : 29, weight: .heavy) : .title2))
                     .fontWeight(.bold)
                     .foregroundColor(.white)
@@ -133,7 +133,7 @@ struct GenreSectionWidget: View {
 
         if !availableGenres.isEmpty {
             VStack(alignment: .leading, spacing: ExperimentalFeatureState.isEnabledAtLaunch ? 18 : 16) {
-                Text(HomeWidgetTitle.forCatalog("genres"))
+                Text(String(localized: String.LocalizationValue(HomeWidgetTitle.forCatalog("genres"))))
                     .font(isTvOS ? .headline : (ExperimentalFeatureState.isEnabledAtLaunch ? .system(size: isIPad ? 34 : 29, weight: .heavy) : .title2))
                     .fontWeight(.bold)
                     .foregroundColor(.white)
@@ -237,7 +237,7 @@ struct CompanySectionWidget: View {
 
         if !availableCompanies.isEmpty {
             VStack(alignment: .leading, spacing: ExperimentalFeatureState.isEnabledAtLaunch ? 18 : 16) {
-                Text(HomeWidgetTitle.forCatalog("companies"))
+                Text(String(localized: String.LocalizationValue(HomeWidgetTitle.forCatalog("companies"))))
                     .font(isTvOS ? .headline : (ExperimentalFeatureState.isEnabledAtLaunch ? .system(size: isIPad ? 34 : 29, weight: .heavy) : .title2))
                     .fontWeight(.bold)
                     .foregroundColor(.white)
@@ -708,7 +708,7 @@ enum HomeWidgetTitle {
 
     private static func fallback(_ id: String) -> String {
         switch id {
-        case "networks": return "Network"
+        case "networks": return "TV Networks"
         case "genres": return "Category"
         case "companies": return "Company"
         default: return ""

--- a/Eclipse/Views/View Elements/ServicesResultsSheet.swift
+++ b/Eclipse/Views/View Elements/ServicesResultsSheet.swift
@@ -1457,7 +1457,7 @@ struct ModulesSearchResultsSheet: View {
 
     private var hasAnyActiveSources: Bool {
         !serviceManager.activeServices.isEmpty
-            || !stremioManager.activeAddons.isEmpty
+            || !stremioManager.activeStreamAddons.isEmpty
             || activeSkyStreamSourceCount > 0
             || activeNuvioSourceCount > 0
     }
@@ -1496,7 +1496,7 @@ struct ModulesSearchResultsSheet: View {
                 + searchedSkyStreamSourceCount
                 + searchedNuvioSourceCount
             let total = viewModel.totalServicesCount
-                + stremioManager.activeAddons.count
+                + stremioManager.activeStreamAddons.count
                 + activeSkyStreamSourceCount
                 + activeNuvioSourceCount
             return "Searching... (\(completed)/\(total))"
@@ -1804,7 +1804,7 @@ struct ModulesSearchResultsSheet: View {
 
     private var sortedResultItems: [ResultItem] {
         let services: [ResultItem] = serviceManager.activeServices.map { .service($0) }
-        let addons: [ResultItem] = stremioManager.activeAddons.map { .stremio($0) }
+        let addons: [ResultItem] = stremioManager.activeStreamAddons.map { .stremio($0) }
 #if os(iOS) && !targetEnvironment(macCatalyst)
         let skyStreamProviders: [ResultItem] = activeSkyStreamProviders.map { .skyStream($0) }
         let nuvioScrapers: [ResultItem] = activeNuvioScrapers.map { .nuvio($0) }
@@ -3456,7 +3456,7 @@ struct ModulesSearchResultsSheet: View {
     @MainActor
     private func refreshVisibleStremioStreams() {
         var refreshed: [UUID: [StremioStream]] = [:]
-        for addon in stremioManager.activeAddons {
+        for addon in stremioManager.activeStreamAddons {
             guard let streams = viewModel.stremioResults[addon.id] else { continue }
             refreshed[addon.id] = filteredStremioStreams(streams, addon: addon)
         }
@@ -7086,7 +7086,7 @@ struct ModulesSearchResultsSheet: View {
     private func startStremioSearch() {
         guard sheetWorkIsActive else { return }
         let searchGeneration = manualSearchGeneration
-        let active = stremioManager.activeAddons
+        let active = stremioManager.activeStreamAddons
         guard !active.isEmpty else {
             viewModel.isSearchingStremio = false
             return

--- a/EclipseTV/Localizable.xcstrings
+++ b/EclipseTV/Localizable.xcstrings
@@ -9,6 +9,12 @@
             "state": "translated",
             "value": "Accent Color"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de acento"
+          }
         }
       }
     },
@@ -19,6 +25,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Activate at least one stream-capable service, addon, or plugin to use Auto Mode."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa al menos un servicio, addon o plugin compatible con transmisión para usar el Modo Automático."
           }
         }
       }
@@ -31,6 +43,12 @@
             "state": "translated",
             "value": "Add"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar"
+          }
         }
       }
     },
@@ -41,6 +59,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Add Service"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar servicio"
           }
         }
       }
@@ -53,6 +77,12 @@
             "state": "translated",
             "value": "Add Stremio Addon"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar addon de Stremio"
+          }
         }
       }
     },
@@ -63,6 +93,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Add to Collection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar a la colección"
           }
         }
       }
@@ -75,6 +111,12 @@
             "state": "translated",
             "value": "Added lists appear in Catalogs for ordering and per-row toggles."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las listas agregadas aparecen en Catálogos para ordenarlas y activarlas por fila."
+          }
         }
       }
     },
@@ -85,6 +127,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del addon"
           }
         }
       }
@@ -97,6 +145,12 @@
             "state": "translated",
             "value": "Affects buttons, links and other interactive elements."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afecta botones, enlaces y otros elementos interactivos."
+          }
         }
       }
     },
@@ -107,6 +161,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Animated Background"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondo animado"
           }
         }
       }
@@ -119,6 +179,12 @@
             "state": "translated",
             "value": "App Experience"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experiencia de la app"
+          }
         }
       }
     },
@@ -129,6 +195,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "App Updates"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones de la app"
           }
         }
       }
@@ -141,6 +213,12 @@
             "state": "translated",
             "value": "Appearance"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apariencia"
+          }
         }
       }
     },
@@ -151,6 +229,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ascending"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ascendente"
           }
         }
       }
@@ -163,6 +247,12 @@
             "state": "translated",
             "value": "Auto Mode"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo automático"
+          }
         }
       }
     },
@@ -173,6 +263,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auto Quality"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calidad automática"
           }
         }
       }
@@ -185,16 +281,11 @@
             "state": "translated",
             "value": "Auto Sync Ratings"
           }
-        }
-      }
-    },
-    "Auto-check GitHub Releases": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auto-check GitHub Releases"
+            "value": "Sincronizar calificaciones automáticamente"
           }
         }
       }
@@ -207,6 +298,12 @@
             "state": "translated",
             "value": "Auto-Select Episodes"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selección automática de episodios"
+          }
         }
       }
     },
@@ -217,6 +314,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Auto-Select Episodes also applies when choosing a source manually. Auto Mode checks enabled sources from top to bottom. Drag to set priority, and turn Auto Quality off when you want to choose stream quality yourself."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La selección automática de episodios también aplica al elegir una fuente manualmente. El Modo Automático revisa las fuentes activadas de arriba hacia abajo. Arrastra para establecer la prioridad y desactiva la Calidad Automática cuando quieras elegir tú mismo la calidad de la transmisión."
           }
         }
       }
@@ -229,6 +332,29 @@
             "state": "translated",
             "value": "Auto-Update Services"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar servicios automáticamente"
+          }
+        }
+      }
+    },
+    "Auto-check GitHub Releases": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-check GitHub Releases"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar lanzamientos de GitHub automáticamente"
+          }
         }
       }
     },
@@ -239,6 +365,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Automatically check for service updates when the app is opened."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busca actualizaciones de servicios automáticamente al abrir la app."
           }
         }
       }
@@ -251,6 +383,12 @@
             "state": "translated",
             "value": "Backup & Import"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia de seguridad e importación"
+          }
         }
       }
     },
@@ -261,6 +399,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Backup & Restore"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia de seguridad y restauración"
           }
         }
       }
@@ -273,6 +417,12 @@
             "state": "translated",
             "value": "Banner color bleeds, then the background takes over"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El color del banner se difumina y luego domina el fondo"
+          }
         }
       }
     },
@@ -283,6 +433,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cancel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         }
       }
@@ -295,6 +451,12 @@
             "state": "translated",
             "value": "Cancel All Active"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar todo lo activo"
+          }
         }
       }
     },
@@ -305,6 +467,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cast"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transmitir"
           }
         }
       }
@@ -317,6 +485,12 @@
             "state": "translated",
             "value": "Catalog name (optional)"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del catálogo (opcional)"
+          }
         }
       }
     },
@@ -327,6 +501,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogos"
           }
         }
       }
@@ -339,6 +519,12 @@
             "state": "translated",
             "value": "Category"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categoría"
+          }
         }
       }
     },
@@ -349,6 +535,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Choose a server to stream from"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un servidor desde el cual transmitir"
           }
         }
       }
@@ -361,6 +553,12 @@
             "state": "translated",
             "value": "Choose a subtitle track"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una pista de subtítulos"
+          }
         }
       }
     },
@@ -371,6 +569,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Choose an episode:"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un episodio:"
           }
         }
       }
@@ -383,6 +587,12 @@
             "state": "translated",
             "value": "Classic"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clásico"
+          }
         }
       }
     },
@@ -393,6 +603,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Classic Gradient"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Degradado clásico"
           }
         }
       }
@@ -405,6 +621,12 @@
             "state": "translated",
             "value": "Clear"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
         }
       }
     },
@@ -415,6 +637,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Clear All Logs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar todos los registros"
           }
         }
       }
@@ -427,6 +655,12 @@
             "state": "translated",
             "value": "Clear Cache?"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Borrar caché?"
+          }
         }
       }
     },
@@ -438,6 +672,12 @@
             "state": "translated",
             "value": "Collection Name"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre de la colección"
+          }
         }
       }
     },
@@ -445,6 +685,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color 1"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Color 1"
@@ -460,6 +706,12 @@
             "state": "translated",
             "value": "Color 2"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color 2"
+          }
         }
       }
     },
@@ -467,6 +719,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color 3"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Color 3"
@@ -482,6 +740,12 @@
             "state": "translated",
             "value": "Community"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comunidad"
+          }
         }
       }
     },
@@ -492,6 +756,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Company"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compañía"
           }
         }
       }
@@ -504,6 +774,12 @@
             "state": "translated",
             "value": "Configuration"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración"
+          }
         }
       }
     },
@@ -514,6 +790,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Configure"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar"
           }
         }
       }
@@ -526,6 +808,12 @@
             "state": "translated",
             "value": "Configure this addon on the web, then use \"Update URL\" to paste the new URL."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configura este addon en la web y luego usa \"Actualizar URL\" para pegar la nueva URL."
+          }
         }
       }
     },
@@ -536,6 +824,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Configured addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del addon configurado"
           }
         }
       }
@@ -548,6 +842,12 @@
             "state": "translated",
             "value": "Connect"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectar"
+          }
         }
       }
     },
@@ -558,6 +858,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Connection Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de conexión"
           }
         }
       }
@@ -570,6 +876,12 @@
             "state": "translated",
             "value": "Content Catalogs"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogos de contenido"
+          }
         }
       }
     },
@@ -580,6 +892,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Copy Log Message"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar mensaje del registro"
           }
         }
       }
@@ -592,6 +910,12 @@
             "state": "translated",
             "value": "Create"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear"
+          }
         }
       }
     },
@@ -602,6 +926,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Create New Collection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear nueva colección"
           }
         }
       }
@@ -614,6 +944,12 @@
             "state": "translated",
             "value": "Custom Background Color"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de fondo personalizado"
+          }
         }
       }
     },
@@ -624,6 +960,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Custom palette colors blend into a multi-gradient. Pick three."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los colores de la paleta personalizada se combinan en un multidegradado. Elige tres."
           }
         }
       }
@@ -636,6 +978,12 @@
             "state": "translated",
             "value": "Custom size"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño personalizado"
+          }
         }
       }
     },
@@ -646,6 +994,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Data"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datos"
           }
         }
       }
@@ -658,6 +1012,12 @@
             "state": "translated",
             "value": "Default"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado"
+          }
         }
       }
     },
@@ -668,6 +1028,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Delete"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
           }
         }
       }
@@ -680,6 +1046,12 @@
             "state": "translated",
             "value": "Delete All"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar todo"
+          }
         }
       }
     },
@@ -690,6 +1062,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Delete Completed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar completados"
           }
         }
       }
@@ -702,6 +1080,12 @@
             "state": "translated",
             "value": "Delete Episode"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar episodio"
+          }
         }
       }
     },
@@ -712,6 +1096,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Descending"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descendente"
           }
         }
       }
@@ -724,6 +1114,12 @@
             "state": "translated",
             "value": "Description (optional)"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descripción (opcional)"
+          }
         }
       }
     },
@@ -734,6 +1130,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Detail Pages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Páginas de detalle"
           }
         }
       }
@@ -746,6 +1148,12 @@
             "state": "translated",
             "value": "Details"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles"
+          }
         }
       }
     },
@@ -756,6 +1164,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Direction"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección"
           }
         }
       }
@@ -768,6 +1182,12 @@
             "state": "translated",
             "value": "Disabled by repo"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deshabilitado por el repositorio"
+          }
         }
       }
     },
@@ -778,6 +1198,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Disconnect"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar"
           }
         }
       }
@@ -790,6 +1216,12 @@
             "state": "translated",
             "value": "Done"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo"
+          }
         }
       }
     },
@@ -800,6 +1232,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Drag rows to change their order. Hidden rows will not appear on media detail pages. Episodes only appear for series. Stills and Trailers appear in the Modern interface."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrastra las filas para cambiar su orden. Las filas ocultas no aparecerán en las páginas de detalle. Los episodios solo aparecen para series. Las capturas y los tráilers aparecen en la interfaz Moderna."
           }
         }
       }
@@ -812,6 +1250,12 @@
             "state": "translated",
             "value": "Eclipse is a GPL-licensed media app with substantial original changes by Soupy-dev."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse es una app multimedia con licencia GPL, con cambios originales considerables realizados por Soupy-dev."
+          }
         }
       }
     },
@@ -822,6 +1266,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eclipse is released under the GNU General Public License version 3."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eclipse se distribuye bajo la Licencia Pública General de GNU versión 3."
           }
         }
       }
@@ -834,6 +1284,12 @@
             "state": "translated",
             "value": "Eclipse's privacy policy explains what data the app stores locally and how optional third-party services are handled."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La política de privacidad de Eclipse explica qué datos almacena la app localmente y cómo se gestionan los servicios opcionales de terceros."
+          }
         }
       }
     },
@@ -844,6 +1300,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Empty"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vacío"
           }
         }
       }
@@ -856,6 +1318,12 @@
             "state": "translated",
             "value": "Enable Sync"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar sincronización"
+          }
         }
       }
     },
@@ -866,6 +1334,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enable/disable content catalogs and drag to reorder them. The order here determines the order on your home screen. Stremio catalog addons may reduce performance or have visual inconsistencies. Trakt catalogs appear after Trakt is connected."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva los catálogos de contenido y arrástralos para reordenarlos. El orden aquí determina el orden en tu pantalla de inicio. Los addons de catálogo de Stremio pueden reducir el rendimiento o tener inconsistencias visuales. Los catálogos de Trakt aparecen después de conectar Trakt."
           }
         }
       }
@@ -878,6 +1352,12 @@
             "state": "translated",
             "value": "Enter decimal number"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa un número decimal"
+          }
         }
       }
     },
@@ -888,6 +1368,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enter number"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa un número"
           }
         }
       }
@@ -900,16 +1386,11 @@
             "state": "translated",
             "value": "Enter text"
           }
-        }
-      }
-    },
-    "Enter the direct JSON file URL": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Enter the direct JSON file URL"
+            "value": "Ingresa texto"
           }
         }
       }
@@ -922,6 +1403,29 @@
             "state": "translated",
             "value": "Enter the Stremio addon manifest URL"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa la URL del manifiesto del addon de Stremio"
+          }
+        }
+      }
+    },
+    "Enter the direct JSON file URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter the direct JSON file URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingresa la URL directa del archivo JSON"
+          }
         }
       }
     },
@@ -929,6 +1433,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Error"
@@ -944,6 +1454,12 @@
             "state": "translated",
             "value": "Export Failed"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportación fallida"
+          }
         }
       }
     },
@@ -954,6 +1470,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Export Logs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar registros"
           }
         }
       }
@@ -966,6 +1488,12 @@
             "state": "translated",
             "value": "Fetching Streams"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obteniendo transmisiones"
+          }
         }
       }
     },
@@ -977,6 +1505,12 @@
             "state": "translated",
             "value": "Filter Settings"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de filtro"
+          }
         }
       }
     },
@@ -984,6 +1518,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Global"
@@ -999,6 +1539,12 @@
             "state": "translated",
             "value": "Global follows the Home Layout orientation. Automatic picks poster or landscape per item."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global sigue la orientación del Diseño de Inicio. Automático elige póster u horizontal según el elemento."
+          }
         }
       }
     },
@@ -1009,6 +1555,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Health check pending"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificación de estado pendiente"
           }
         }
       }
@@ -1021,6 +1573,12 @@
             "state": "translated",
             "value": "Help support the app. Any amount helps keep the app free for everyone"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayuda a apoyar la app. Cualquier cantidad ayuda a mantenerla gratuita para todos"
+          }
         }
       }
     },
@@ -1031,6 +1589,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Help support the app. Any amount helps keep the app free for everyone. Thanks for using the app and supporting development!"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayuda a apoyar la app. Cualquier cantidad ayuda a mantenerla gratuita para todos. ¡Gracias por usar la app y apoyar su desarrollo!"
           }
         }
       }
@@ -1043,6 +1607,12 @@
             "state": "translated",
             "value": "Hero"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destacado"
+          }
         }
       }
     },
@@ -1053,6 +1623,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hide Splash Screen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar pantalla de bienvenida"
           }
         }
       }
@@ -1065,6 +1641,12 @@
             "state": "translated",
             "value": "Higher"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más alto"
+          }
         }
       }
     },
@@ -1075,6 +1657,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Highest"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más alto"
           }
         }
       }
@@ -1087,6 +1675,12 @@
             "state": "translated",
             "value": "Home"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicio"
+          }
         }
       }
     },
@@ -1098,16 +1692,11 @@
             "state": "translated",
             "value": "Home Layout"
           }
-        }
-      }
-    },
-    "iCloud Sync": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "iCloud Sync"
+            "value": "Diseño de inicio"
           }
         }
       }
@@ -1120,6 +1709,12 @@
             "state": "translated",
             "value": "Import"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar"
+          }
         }
       }
     },
@@ -1130,6 +1725,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Import AniList Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar biblioteca de AniList"
           }
         }
       }
@@ -1142,6 +1743,12 @@
             "state": "translated",
             "value": "Import MAL Library"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar biblioteca de MAL"
+          }
         }
       }
     },
@@ -1152,6 +1759,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Import Trakt Library"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar biblioteca de Trakt"
           }
         }
       }
@@ -1164,6 +1777,12 @@
             "state": "translated",
             "value": "Import your Watching, Planning, and Completed lists as collections"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa tus listas de Viendo, Planeando y Completado como colecciones"
+          }
         }
       }
     },
@@ -1174,6 +1793,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Import your watchlist and watched progress as collections"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importa tu lista de seguimiento y progreso visto como colecciones"
           }
         }
       }
@@ -1186,6 +1811,12 @@
             "state": "translated",
             "value": "Informations Language"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma de la información"
+          }
         }
       }
     },
@@ -1196,6 +1827,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Interface & Scope"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interfaz y alcance"
           }
         }
       }
@@ -1208,6 +1845,12 @@
             "state": "translated",
             "value": "JSON URL"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL de JSON"
+          }
         }
       }
     },
@@ -1218,6 +1861,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Language"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma"
           }
         }
       }
@@ -1230,6 +1879,12 @@
             "state": "translated",
             "value": "Large sync: Eclipse will show progress, honor rate limits, and keep this sheet open until it finishes or you cancel."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización grande: Eclipse mostrará el progreso, respetará los límites de solicitudes y mantendrá esta ventana abierta hasta que termine o la canceles."
+          }
         }
       }
     },
@@ -1240,6 +1895,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Legal & Source"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legal y código fuente"
           }
         }
       }
@@ -1252,6 +1913,12 @@
             "state": "translated",
             "value": "Library"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biblioteca"
+          }
         }
       }
     },
@@ -1262,6 +1929,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Live Trakt Scrobbling"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scrobbling en vivo de Trakt"
           }
         }
       }
@@ -1274,6 +1947,12 @@
             "state": "translated",
             "value": "Loading amazing content..."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando contenido increíble..."
+          }
         }
       }
     },
@@ -1284,6 +1963,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Loading episodes..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando episodios..."
           }
         }
       }
@@ -1296,6 +1981,12 @@
             "state": "translated",
             "value": "Loading settings..."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando ajustes..."
+          }
         }
       }
     },
@@ -1307,6 +1998,12 @@
             "state": "translated",
             "value": "Loading..."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando..."
+          }
         }
       }
     },
@@ -1314,6 +2011,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Local"
@@ -1329,6 +2032,12 @@
             "state": "translated",
             "value": "Logger"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registro"
+          }
         }
       }
     },
@@ -1339,6 +2048,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lower"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más bajo"
           }
         }
       }
@@ -1351,6 +2066,12 @@
             "state": "translated",
             "value": "Lowest"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más bajo"
+          }
         }
       }
     },
@@ -1362,38 +2083,11 @@
             "state": "translated",
             "value": "Manual Select"
           }
-        }
-      }
-    },
-    "Mark as Not Watched": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mark as Not Watched"
-          }
-        }
-      }
-    },
-    "Mark as Unwatched": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mark as Unwatched"
-          }
-        }
-      }
-    },
-    "Mark as Watched": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mark as Watched"
+            "value": "Selección manual"
           }
         }
       }
@@ -1406,6 +2100,12 @@
             "state": "translated",
             "value": "Mark Previous as Not Watched"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar anteriores como no vistos"
+          }
         }
       }
     },
@@ -1416,6 +2116,63 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mark Previous as Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar anteriores como vistos"
+          }
+        }
+      }
+    },
+    "Mark as Not Watched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark as Not Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar como no visto"
+          }
+        }
+      }
+    },
+    "Mark as Unwatched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark as Unwatched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar como no visto"
+          }
+        }
+      }
+    },
+    "Mark as Watched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark as Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar como visto"
           }
         }
       }
@@ -1428,6 +2185,12 @@
             "state": "translated",
             "value": "Matching Algorithm"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algoritmo de coincidencia"
+          }
         }
       }
     },
@@ -1438,6 +2201,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Media Detail Page"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página de detalle multimedia"
           }
         }
       }
@@ -1450,6 +2219,12 @@
             "state": "translated",
             "value": "Media Player"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproductor multimedia"
+          }
         }
       }
     },
@@ -1460,6 +2235,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Medium"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medio"
           }
         }
       }
@@ -1472,6 +2253,12 @@
             "state": "translated",
             "value": "Message"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensaje"
+          }
         }
       }
     },
@@ -1482,6 +2269,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Modern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moderno"
           }
         }
       }
@@ -1494,6 +2287,12 @@
             "state": "translated",
             "value": "Movies"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Películas"
+          }
         }
       }
     },
@@ -1504,6 +2303,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Multi Gradient"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Multidegradado"
           }
         }
       }
@@ -1516,6 +2321,12 @@
             "state": "translated",
             "value": "Network"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red"
+          }
         }
       }
     },
@@ -1526,6 +2337,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "New Addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva URL de addon"
           }
         }
       }
@@ -1538,6 +2355,12 @@
             "state": "translated",
             "value": "New Collection"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva colección"
+          }
         }
       }
     },
@@ -1548,6 +2371,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No Active Services"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin servicios activos"
           }
         }
       }
@@ -1560,60 +2389,11 @@
             "state": "translated",
             "value": "No Active Sources"
           }
-        }
-      }
-    },
-    "No episodes scheduled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No episodes scheduled"
-          }
-        }
-      }
-    },
-    "No items in this collection": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No items in this collection"
-          }
-        }
-      }
-    },
-    "No plugin providers installed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No plugin providers installed"
-          }
-        }
-      }
-    },
-    "No plugin repositories installed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No plugin repositories installed"
-          }
-        }
-      }
-    },
-    "No results found": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No results found"
+            "value": "Sin fuentes activas"
           }
         }
       }
@@ -1626,16 +2406,11 @@
             "state": "translated",
             "value": "No Services"
           }
-        }
-      }
-    },
-    "No services or addons installed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No services or addons installed"
+            "value": "Sin servicios"
           }
         }
       }
@@ -1648,6 +2423,12 @@
             "state": "translated",
             "value": "No Settings Available"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay ajustes disponibles"
+          }
         }
       }
     },
@@ -1658,6 +2439,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No Subtitles"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin subtítulos"
           }
         }
       }
@@ -1670,6 +2457,114 @@
             "state": "translated",
             "value": "No TMDB Entry"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin entrada de TMDB"
+          }
+        }
+      }
+    },
+    "No episodes scheduled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No episodes scheduled"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay episodios programados"
+          }
+        }
+      }
+    },
+    "No items in this collection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No items in this collection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay elementos en esta colección"
+          }
+        }
+      }
+    },
+    "No plugin providers installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No plugin providers installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay proveedores de plugins instalados"
+          }
+        }
+      }
+    },
+    "No plugin repositories installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No plugin repositories installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay repositorios de plugins instalados"
+          }
+        }
+      }
+    },
+    "No results found": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No results found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron resultados"
+          }
+        }
+      }
+    },
+    "No services or addons installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No services or addons installed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay servicios ni addons instalados"
+          }
         }
       }
     },
@@ -1681,6 +2576,12 @@
             "state": "translated",
             "value": "None"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguno"
+          }
         }
       }
     },
@@ -1688,6 +2589,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Normal"
@@ -1703,16 +2610,11 @@
             "state": "translated",
             "value": "Not searched"
           }
-        }
-      }
-    },
-    "Off follows the global size. Widget rows support size only.": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Off follows the global size. Widget rows support size only."
+            "value": "No buscado"
           }
         }
       }
@@ -1725,6 +2627,29 @@
             "state": "translated",
             "value": "OK"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
+          }
+        }
+      }
+    },
+    "Off follows the global size. Widget rows support size only.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off follows the global size. Widget rows support size only."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivado sigue el tamaño global. Las filas de widgets solo admiten tamaño."
+          }
         }
       }
     },
@@ -1735,6 +2660,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Optional"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcional"
           }
         }
       }
@@ -1747,6 +2678,12 @@
             "state": "translated",
             "value": "Orientation"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orientación"
+          }
         }
       }
     },
@@ -1757,6 +2694,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Others"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otros"
           }
         }
       }
@@ -1769,6 +2712,12 @@
             "state": "translated",
             "value": "Palette"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paleta"
+          }
         }
       }
     },
@@ -1779,6 +2728,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Paste the new configured addon URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pega la nueva URL del addon configurado"
           }
         }
       }
@@ -1791,6 +2746,12 @@
             "state": "translated",
             "value": "Pause"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar"
+          }
         }
       }
     },
@@ -1801,6 +2762,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pause All"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar todo"
           }
         }
       }
@@ -1813,6 +2780,12 @@
             "state": "translated",
             "value": "Per Catalog"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por catálogo"
+          }
         }
       }
     },
@@ -1823,6 +2796,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Performance Mode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de rendimiento"
           }
         }
       }
@@ -1835,6 +2814,12 @@
             "state": "translated",
             "value": "Play"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducir"
+          }
         }
       }
     },
@@ -1842,6 +2827,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plugins"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "Plugins"
@@ -1857,6 +2848,12 @@
             "state": "translated",
             "value": "Preview"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista previa"
+          }
         }
       }
     },
@@ -1867,6 +2864,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Preview imports, pushes, and AniList/MAL ports"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista previa de importaciones, envíos y migraciones de AniList/MAL"
           }
         }
       }
@@ -1879,6 +2882,12 @@
             "state": "translated",
             "value": "Quality"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calidad"
+          }
         }
       }
     },
@@ -1889,6 +2898,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Quality Threshold"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbral de calidad"
           }
         }
       }
@@ -1901,6 +2916,12 @@
             "state": "translated",
             "value": "Rating & Notes"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calificación y notas"
+          }
         }
       }
     },
@@ -1911,6 +2932,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reachable"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcanzable"
           }
         }
       }
@@ -1923,6 +2950,12 @@
             "state": "translated",
             "value": "Recalculate cache size"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recalcular tamaño de caché"
+          }
         }
       }
     },
@@ -1933,6 +2966,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Recent Searches"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Búsquedas recientes"
           }
         }
       }
@@ -1945,6 +2984,12 @@
             "state": "translated",
             "value": "Reconfigure Addon"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconfigurar addon"
+          }
         }
       }
     },
@@ -1955,6 +3000,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reconfigure Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al reconfigurar"
           }
         }
       }
@@ -1967,6 +3018,12 @@
             "state": "translated",
             "value": "Remove"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar"
+          }
         }
       }
     },
@@ -1977,6 +3034,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Repository URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del repositorio"
           }
         }
       }
@@ -1989,6 +3052,12 @@
             "state": "translated",
             "value": "Requires MoltenVK MPV"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requiere MoltenVK MPV"
+          }
         }
       }
     },
@@ -1999,6 +3068,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reset All Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer todos los catálogos"
           }
         }
       }
@@ -2011,6 +3086,12 @@
             "state": "translated",
             "value": "Reset Appearance"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer apariencia"
+          }
         }
       }
     },
@@ -2021,6 +3102,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reset Media Detail Layout"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer diseño de detalle multimedia"
           }
         }
       }
@@ -2033,6 +3120,12 @@
             "state": "translated",
             "value": "Reset Progress"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer progreso"
+          }
         }
       }
     },
@@ -2043,6 +3136,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reset to Global"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer a global"
           }
         }
       }
@@ -2055,6 +3154,12 @@
             "state": "translated",
             "value": "Resets theme, layout and per-catalog overrides to their defaults."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablece el tema, el diseño y las anulaciones por catálogo a sus valores predeterminados."
+          }
         }
       }
     },
@@ -2065,6 +3170,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Resets theme, layout, app experience, and per-catalog overrides to their defaults."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablece el tema, el diseño, la experiencia de la app y las anulaciones por catálogo a sus valores predeterminados."
           }
         }
       }
@@ -2077,6 +3188,12 @@
             "state": "translated",
             "value": "Restart Required"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requiere reiniciar"
+          }
         }
       }
     },
@@ -2087,6 +3204,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restart required to apply the interface change"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requiere reiniciar para aplicar el cambio de interfaz"
           }
         }
       }
@@ -2099,6 +3222,12 @@
             "state": "translated",
             "value": "Restore"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar"
+          }
         }
       }
     },
@@ -2109,6 +3238,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restore Confirmation"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmar restauración"
           }
         }
       }
@@ -2121,6 +3256,12 @@
             "state": "translated",
             "value": "Restore the default order and visibility."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaura el orden y la visibilidad predeterminados."
+          }
         }
       }
     },
@@ -2131,6 +3272,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restore the default theme and layout values."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaura los valores predeterminados de tema y diseño."
           }
         }
       }
@@ -2143,6 +3290,12 @@
             "state": "translated",
             "value": "Restore the default theme, layout, animation, and startup display values."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaura los valores predeterminados de tema, diseño, animación y pantalla de inicio."
+          }
         }
       }
     },
@@ -2153,6 +3306,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Resume"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar"
           }
         }
       }
@@ -2165,6 +3324,12 @@
             "state": "translated",
             "value": "Resume All"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar todo"
+          }
         }
       }
     },
@@ -2175,6 +3340,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Retry"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintentar"
           }
         }
       }
@@ -2187,6 +3358,12 @@
             "state": "translated",
             "value": "Retry Failed"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintento fallido"
+          }
         }
       }
     },
@@ -2197,6 +3374,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Review"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reseña"
           }
         }
       }
@@ -2209,6 +3392,12 @@
             "state": "translated",
             "value": "Rows set to Global follow the settings above. Orientation applies to standard poster rows; widget rows support size only."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las filas configuradas como Global siguen los ajustes anteriores. La orientación aplica a las filas de pósters estándar; las filas de widgets solo admiten tamaño."
+          }
         }
       }
     },
@@ -2219,6 +3408,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Run"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar"
           }
         }
       }
@@ -2231,6 +3426,12 @@
             "state": "translated",
             "value": "Run Sync Tool?"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Ejecutar herramienta de sincronización?"
+          }
         }
       }
     },
@@ -2241,6 +3442,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Save"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
           }
         }
       }
@@ -2253,6 +3460,12 @@
             "state": "translated",
             "value": "Schedule"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calendario"
+          }
         }
       }
     },
@@ -2263,6 +3476,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Search"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
           }
         }
       }
@@ -2275,6 +3494,12 @@
             "state": "translated",
             "value": "Search Movies & TV Shows"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar películas y series"
+          }
         }
       }
     },
@@ -2285,6 +3510,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Search..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcador de posición de búsqueda"
           }
         }
       }
@@ -2297,6 +3528,12 @@
             "state": "translated",
             "value": "Searching for:"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando:"
+          }
         }
       }
     },
@@ -2307,6 +3544,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Searching..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando..."
           }
         }
       }
@@ -2319,6 +3562,12 @@
             "state": "translated",
             "value": "Seasons"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temporadas"
+          }
         }
       }
     },
@@ -2329,6 +3578,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Services"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servicios"
           }
         }
       }
@@ -2341,6 +3596,12 @@
             "state": "translated",
             "value": "Services & Addons"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servicios y addons"
+          }
         }
       }
     },
@@ -2351,6 +3612,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
           }
         }
       }
@@ -2363,6 +3630,12 @@
             "state": "translated",
             "value": "Settings Saved"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes guardados"
+          }
         }
       }
     },
@@ -2374,16 +3647,11 @@
             "state": "translated",
             "value": "Share"
           }
-        }
-      }
-    },
-    "Shows": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Shows"
+            "value": "Compartir"
           }
         }
       }
@@ -2396,6 +3664,29 @@
             "state": "translated",
             "value": "Show ambient motion behind the home screen."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra movimiento ambiental detrás de la pantalla de inicio."
+          }
+        }
+      }
+    },
+    "Shows": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Series"
+          }
         }
       }
     },
@@ -2406,6 +3697,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño"
           }
         }
       }
@@ -2418,6 +3715,12 @@
             "state": "translated",
             "value": "Size and orientation of home rows - globally or per catalog."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño y orientación de las filas de inicio, de forma global o por catálogo."
+          }
         }
       }
     },
@@ -2428,6 +3731,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Skip"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitir"
           }
         }
       }
@@ -2440,6 +3749,12 @@
             "state": "translated",
             "value": "Skip Episode"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitir episodio"
+          }
         }
       }
     },
@@ -2450,6 +3765,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Skip the launch splash once Eclipse opens."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omite la pantalla de bienvenida al abrir Eclipse."
           }
         }
       }
@@ -2462,6 +3783,12 @@
             "state": "translated",
             "value": "Solid Color"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color sólido"
+          }
         }
       }
     },
@@ -2472,6 +3799,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sort"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordenar"
           }
         }
       }
@@ -2484,6 +3817,12 @@
             "state": "translated",
             "value": "Specials & OVAs"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Especiales y OVAs"
+          }
         }
       }
     },
@@ -2494,6 +3833,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Stay here while this large sync runs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permanece aquí mientras se ejecuta esta sincronización grande"
           }
         }
       }
@@ -2506,6 +3851,12 @@
             "state": "translated",
             "value": "Storage"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento"
+          }
         }
       }
     },
@@ -2516,6 +3867,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Stream Error"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de transmisión"
           }
         }
       }
@@ -2528,6 +3885,12 @@
             "state": "translated",
             "value": "Stremio Error"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de Stremio"
+          }
         }
       }
     },
@@ -2538,6 +3901,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Support"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soporte"
           }
         }
       }
@@ -2550,6 +3919,12 @@
             "state": "translated",
             "value": "Switch Mode Animation"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animación al cambiar de modo"
+          }
         }
       }
     },
@@ -2560,6 +3935,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sync Tools"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramientas de sincronización"
           }
         }
       }
@@ -2572,6 +3953,12 @@
             "state": "translated",
             "value": "The interface style is applied when Eclipse launches. Restart the app to switch between the Modern and Classic layouts."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estilo de interfaz se aplica cuando Eclipse se inicia. Reinicia la app para cambiar entre los diseños Moderno y Clásico."
+          }
         }
       }
     },
@@ -2582,6 +3969,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "The service settings have been updated successfully."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los ajustes del servicio se actualizaron correctamente."
           }
         }
       }
@@ -2594,6 +3987,12 @@
             "state": "translated",
             "value": "Theme"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema"
+          }
         }
       }
     },
@@ -2604,6 +4003,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "These apply to every home row. Override individual rows below."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estos se aplican a todas las filas de inicio. Anúlalos individualmente por fila más abajo."
           }
         }
       }
@@ -2616,6 +4021,12 @@
             "state": "translated",
             "value": "Thick"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grueso"
+          }
         }
       }
     },
@@ -2626,6 +4037,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Thin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delgado"
           }
         }
       }
@@ -2638,6 +4055,12 @@
             "state": "translated",
             "value": "This program comes with no warranty, to the extent permitted by law."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este programa no ofrece garantía alguna, en la medida permitida por la ley."
+          }
         }
       }
     },
@@ -2648,6 +4071,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This service doesn't have configurable settings."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este servicio no tiene ajustes configurables."
           }
         }
       }
@@ -2660,6 +4089,12 @@
             "state": "translated",
             "value": "This will import your AniList lists as Eclipse collections and fill local watch/read progress without deleting or downgrading anything."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto importará tus listas de AniList como colecciones de Eclipse y completará el progreso local de visualización/lectura sin eliminar ni retroceder nada."
+          }
         }
       }
     },
@@ -2670,6 +4105,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will import your MAL lists as Eclipse collections and fill local watch/read progress without deleting or downgrading anything."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto importará tus listas de MAL como colecciones de Eclipse y completará el progreso local de visualización/lectura sin eliminar ni retroceder nada."
           }
         }
       }
@@ -2682,6 +4123,12 @@
             "state": "translated",
             "value": "This will import your Trakt watchlist and watched progress as Eclipse collections without deleting or downgrading anything."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto importará tu lista de seguimiento y progreso visto de Trakt como colecciones de Eclipse sin eliminar ni retroceder nada."
+          }
         }
       }
     },
@@ -2692,6 +4139,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "This will overwrite your current settings, collections, watch progress, tracker logins including MAL, and service configurations with the backup data. Continue?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto sobrescribirá tus ajustes actuales, colecciones, progreso de visualización, inicios de sesión de rastreadores (incluido MAL) y configuraciones de servicios con los datos de la copia de seguridad. ¿Continuar?"
           }
         }
       }
@@ -2704,6 +4157,12 @@
             "state": "translated",
             "value": "This writes progress to the selected destination but never deletes entries or downgrades progress."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto escribe el progreso en el destino seleccionado, pero nunca elimina entradas ni retrocede el progreso."
+          }
         }
       }
     },
@@ -2714,6 +4173,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Threshold (0.0 - 1.0)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umbral (0.0 - 1.0)"
           }
         }
       }
@@ -2726,6 +4191,12 @@
             "state": "translated",
             "value": "Timezone"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zona horaria"
+          }
         }
       }
     },
@@ -2736,6 +4207,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Trackers"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rastreadores"
           }
         }
       }
@@ -2748,71 +4225,11 @@
             "state": "translated",
             "value": "Trakt Features"
           }
-        }
-      }
-    },
-    "Trakt list URL or ID": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trakt list URL or ID"
-          }
-        }
-      }
-    },
-    "Trakt Public Catalogs": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trakt Public Catalogs"
-          }
-        }
-      }
-    },
-    "Trakt Reviews": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trakt Reviews"
-          }
-        }
-      }
-    },
-    "Try adjusting your filter or search for something else": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try adjusting your filter or search for something else"
-          }
-        }
-      }
-    },
-    "Try Again": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try Again"
-          }
-        }
-      }
-    },
-    "Try searching for a different movie or TV show": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try searching for a different movie or TV show"
+            "value": "Funciones de Trakt"
           }
         }
       }
@@ -2825,6 +4242,114 @@
             "state": "translated",
             "value": "Type"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo de lista de Trakt"
+          }
+        }
+      }
+    },
+    "Trakt Public Catalogs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trakt Public Catalogs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catálogos públicos de Trakt"
+          }
+        }
+      }
+    },
+    "Trakt Reviews": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trakt Reviews"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reseñas de Trakt"
+          }
+        }
+      }
+    },
+    "Trakt list URL or ID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trakt list URL or ID"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL o ID de lista de Trakt"
+          }
+        }
+      }
+    },
+    "Try Again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try Again"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intentar de nuevo"
+          }
+        }
+      }
+    },
+    "Try adjusting your filter or search for something else": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try adjusting your filter or search for something else"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intenta ajustar el filtro o busca otra cosa"
+          }
+        }
+      }
+    },
+    "Try searching for a different movie or TV show": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try searching for a different movie or TV show"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intenta buscar otra película o serie"
+          }
         }
       }
     },
@@ -2835,6 +4360,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Update URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar URL"
           }
         }
       }
@@ -2847,6 +4378,12 @@
             "state": "translated",
             "value": "View"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver"
+          }
         }
       }
     },
@@ -2857,6 +4394,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Watch Now"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver ahora"
           }
         }
       }
@@ -2869,6 +4412,29 @@
             "state": "translated",
             "value": "You don't have any active services, Stremio addons, or plugins. Add or enable a source in Settings."
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tienes servicios activos, addons de Stremio ni plugins. Agrega o activa una fuente en Ajustes."
+          }
+        }
+      }
+    },
+    "iCloud Sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud Sync"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronización con iCloud"
+          }
         }
       }
     },
@@ -2879,6 +4445,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• Watched"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Visto"
           }
         }
       }


### PR DESCRIPTION
**Interface language (Settings > Language)**
- New "Language" setting (System / English / Español), first item under Basic, matching the existing screen layout.
- Selecting a language updates `AppleLanguages` and applies on next launch (with a "Restart Required" alert), same pattern as the existing Modern/Classic layout switch.
- Translated the current `Localizable.xcstrings` catalog to Spanish (278/278 entries).

**Home card display + per-catalog customization (moved from Appearance > Home Layout into Settings > Catalogs)**
- Orientation and Size, previously global-only in Home Layout, now live in Catalogs.
- New "Card Info" option: choose Title/Year/Rating, Title only, Title/Year, Title/Rating, or Poster only.
- Each catalog can override Orientation / Size / Card Info individually via a new per-catalog "Customize" screen, or leave it on "Global" to follow the app-wide setting. Catalogs with an override show a "Custom" label.
- Home Layout keeps everything not catalog-specific (density, roundness, spacing, animated background, hero).

**Better Posters (btttr.cc) integration**
- New "Poster Artwork" section in Catalogs: paste your Better Posters URL pattern (`{imdb_id}` placeholder), enable/disable.
- Optional "Apply to Home Screen" toggle (off by default) — resolves each title's IMDb id via a lightweight `external_ids` request and caches it in memory, since home cards only carry a TMDB id.

## Known limitations
- Spanish translation only covers strings already in the String Catalog; most literal `Text("...")` calls elsewhere in the app aren't extracted yet, so a lot of the UI will still show English until that's done incrementally. (if you agree with this PR i can make the whole interface in Spanish)
- Better Posters is wired into the two home-screen card components; Media Detail page artwork isn't using it yet (would be close to free perf-wise since IMDb id is already fetched there, but I didn't want to touch that file's poster/backdrop logic blind).
- tvOS layout for the new Catalogs/Language sections is functional but not fully restyled to match the existing tvOS card treatment elsewhere.

## Testing
- Built via CI only (no local Xcode/Mac available) — see Actions run on this PR for iOS/tvOS build status.